### PR TITLE
Add lexical order solution

### DIFF
--- a/src/main/kotlin/problems/LexicographicalNumbers.kt
+++ b/src/main/kotlin/problems/LexicographicalNumbers.kt
@@ -1,0 +1,31 @@
+package problems
+
+/**
+ * Return the integers 1 … n in lexicographic order.
+ *
+ * Time   O(n)
+ * Memory O(1)  (aside from the result list of size n)
+ */
+fun lexicalOrder(upperLimit: Int): List<Int> {
+  val lexicographicalNumbers = IntArray(upperLimit)
+
+  var currentNumber = 1
+  for (indexInResult in 0 until upperLimit) {
+    lexicographicalNumbers[indexInResult] = currentNumber
+
+    // 1. Prefer the left-most child in the prefix tree.
+    if (currentNumber * 10 <= upperLimit) {
+      currentNumber *= 10
+      continue
+    }
+
+    // 2. Otherwise climb up until a right sibling exists …
+    while (currentNumber % 10 == 9 || currentNumber + 1 > upperLimit) {
+      currentNumber /= 10
+    }
+    // … then step to that sibling.
+    currentNumber += 1
+  }
+
+  return lexicographicalNumbers.asList()
+}

--- a/src/test/kotlin/problems/LexicographicalNumbersTest.kt
+++ b/src/test/kotlin/problems/LexicographicalNumbersTest.kt
@@ -1,0 +1,18 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class LexicographicalNumbersTest {
+  @Test
+  fun testSmallValues() {
+    assertContentEquals(listOf(1), lexicalOrder(1))
+    assertContentEquals(listOf(1, 2), lexicalOrder(2))
+  }
+
+  @Test
+  fun testExample() {
+    val expected = listOf(1, 10, 11, 12, 13, 2, 3, 4, 5, 6, 7, 8, 9)
+    assertContentEquals(expected, lexicalOrder(13))
+  }
+}


### PR DESCRIPTION
## Summary
- implement lexical order generation algorithm
- add tests for lexical order

## Testing
- `./gradlew test`
- `./gradlew detekt` *(fails: Analysis failed with 2933 weighted issues)*

------
https://chatgpt.com/codex/tasks/task_e_684523d5694083219adb2c362b2be74a