### PR TITLE
Add solution for K-th Smallest in Lexicographical Order

### DIFF
--- a/src/main/kotlin/problems/KthSmallestLexicographicalOrder.kt
+++ b/src/main/kotlin/problems/KthSmallestLexicographicalOrder.kt
@@ -1,0 +1,40 @@
+package problems
+
+/**
+ * 440. K-th Smallest in Lexicographical Order
+ *
+ * Time Complexity: O(log_n^2) where n is the limit – each level of the tree is
+ * traversed at most once.
+ * Space Complexity: O(1)
+ */
+fun findKthNumber(limit: Int, k: Int): Int {
+  var remainingMoves = k - 1  // start at "1"
+  var prefix = 1L
+
+  val bound = limit.toLong()
+  while (remainingMoves > 0) {
+    val steps = countSteps(bound, prefix, prefix + 1)
+    if (steps <= remainingMoves) {
+      remainingMoves -= steps
+      prefix += 1
+    } else {
+      remainingMoves -= 1
+      prefix *= 10
+    }
+  }
+  return prefix.toInt()
+}
+
+/** Number of integers ≤ limit that start with any prefix in [firstPrefixStart, nextPrefixStart). */
+private fun countSteps(limit: Long, firstPrefixStart: Long, nextPrefixStart: Long): Int {
+  var lower = firstPrefixStart
+  var upper = nextPrefixStart
+  var total = 0L
+
+  while (lower <= limit) {
+    total += (minOf(limit + 1, upper) - lower)
+    lower *= 10
+    upper *= 10
+  }
+  return total.toInt()
+}

--- a/src/test/kotlin/problems/KthSmallestLexicographicalOrderTest.kt
+++ b/src/test/kotlin/problems/KthSmallestLexicographicalOrderTest.kt
@@ -1,0 +1,12 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class KthSmallestLexicographicalOrderTest {
+  @Test
+  fun testExamples() {
+    assertEquals(10, findKthNumber(13, 2))
+    assertEquals(1, findKthNumber(1, 1))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `findKthNumber` algorithm with helper `countSteps`
- add unit tests for sample cases

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68464a9279148321adfb44108f07cb6e