### PR TITLE
feat: add maximum difference frequency solution

### DIFF
--- a/src/main/kotlin/problems/MaximumDifferenceBetweenEvenAndOddFrequencyI.kt
+++ b/src/main/kotlin/problems/MaximumDifferenceBetweenEvenAndOddFrequencyI.kt
@@ -1,0 +1,26 @@
+package problems
+
+fun maxDifference(s: String): Int {
+  val frequencyMap = IntArray(26)
+  for (character in s) {
+    frequencyMap[character - 'a'] += 1
+  }
+
+  var maxOdd = Int.MIN_VALUE
+  var minEven = Int.MAX_VALUE
+
+  for (frequency in frequencyMap) {
+    if (frequency == 0) continue
+    if (frequency % 2 == 1) {
+      maxOdd = maxOf(maxOdd, frequency)
+    } else {
+      minEven = minOf(minEven, frequency)
+    }
+  }
+
+  return if (maxOdd == Int.MIN_VALUE || minEven == Int.MAX_VALUE) {
+    -1
+  } else {
+    maxOdd - minEven
+  }
+}

--- a/src/test/kotlin/problems/MaximumDifferenceBetweenEvenAndOddFrequencyITest.kt
+++ b/src/test/kotlin/problems/MaximumDifferenceBetweenEvenAndOddFrequencyITest.kt
@@ -1,0 +1,12 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class MaximumDifferenceBetweenEvenAndOddFrequencyITest {
+  @Test
+  fun testMaxDifference() {
+    assertEquals(3, maxDifference("aaaaabbc"))
+    assertEquals(1, maxDifference("abcabcab"))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `maxDifference` to calculate difference between odd and even character frequencies
- add unit tests for the new algorithm

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_6847e2b3727883219a17b2bf110ab536