### PR TITLE
feat(leetcode): add remapping digit difference

### DIFF
--- a/src/main/kotlin/problems/MaximumDifferenceByRemappingDigit.kt
+++ b/src/main/kotlin/problems/MaximumDifferenceByRemappingDigit.kt
@@ -1,0 +1,30 @@
+package problems
+
+/**
+ * Returns the difference between the maximum and minimum values that can be
+ * obtained by remapping exactly one digit in [num].
+ *
+ * A digit can be remapped to itself and all occurrences of the chosen digit
+ * will be replaced. Leading zeroes in the resulting number are allowed.
+ */
+fun minMaxDifference(num: Int): Int {
+  val digits = num.toString()
+
+  // Build the maximum value by replacing the first non-'9' digit with '9'
+  val firstNotNine = digits.firstOrNull { it != '9' }
+  val maxValue = if (firstNotNine == null) {
+    num
+  } else {
+    digits.replace(firstNotNine, '9').toInt()
+  }
+
+  // Build the minimum value by replacing the first non-'0' digit with '0'
+  val firstNotZero = digits.firstOrNull { it != '0' }
+  val minValue = if (firstNotZero == null) {
+    num
+  } else {
+    digits.replace(firstNotZero, '0').toInt()
+  }
+
+  return maxValue - minValue
+}

--- a/src/test/kotlin/problems/MaximumDifferenceByRemappingDigitTest.kt
+++ b/src/test/kotlin/problems/MaximumDifferenceByRemappingDigitTest.kt
@@ -1,0 +1,18 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class MaximumDifferenceByRemappingDigitTest {
+  @Test
+  fun providedExamples() {
+    assertEquals(99009, minMaxDifference(11891))
+    assertEquals(99, minMaxDifference(90))
+  }
+
+  @Test
+  fun additionalCases() {
+    assertEquals(9, minMaxDifference(0))
+    assertEquals(90000, minMaxDifference(10000))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `minMaxDifference` to calculate max/min difference after digit remap
- add unit tests for the new function

## Testing
- `./gradlew test` *(fails: No matching toolchains found)*
- `./gradlew detekt` *(fails: No matching toolchains found)*

------
https://chatgpt.com/codex/tasks/task_e_684d50cb3cdc83219694faac7964cfb5