### PR TITLE
feat(problems): add divideString helper

### DIFF
--- a/src/main/kotlin/problems/DivideStringIntoGroupsOfSizeK.kt
+++ b/src/main/kotlin/problems/DivideStringIntoGroupsOfSizeK.kt
@@ -1,0 +1,22 @@
+package problems
+
+fun divideString(original: String, groupSize: Int, fill: Char): Array<String> {
+  val totalGroups = (original.length + groupSize - 1) / groupSize
+  val groupedStrings = Array(totalGroups) { "" }
+
+  var groupIndex = 0
+  var startIndex = 0
+  while (startIndex < original.length) {
+    val endIndexExclusive = (startIndex + groupSize).coerceAtMost(original.length)
+    var currentGroup = original.substring(startIndex, endIndexExclusive)
+
+    if (currentGroup.length < groupSize) {
+      currentGroup = currentGroup.padEnd(groupSize, fill)
+    }
+
+    groupedStrings[groupIndex++] = currentGroup
+    startIndex += groupSize
+  }
+
+  return groupedStrings
+}

--- a/src/test/kotlin/problems/DivideStringIntoGroupsOfSizeKTest.kt
+++ b/src/test/kotlin/problems/DivideStringIntoGroupsOfSizeKTest.kt
@@ -1,0 +1,30 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+
+class DivideStringIntoGroupsOfSizeKTest {
+  @Test
+  fun `exact multiple of group size`() {
+    val result = divideString("abcdef", 2, 'x')
+    assertContentEquals(arrayOf("ab", "cd", "ef"), result)
+  }
+
+  @Test
+  fun `requires padding`() {
+    val result = divideString("abcdefghij", 3, 'x')
+    assertContentEquals(arrayOf("abc", "def", "ghi", "jxx"), result)
+  }
+
+  @Test
+  fun `group size of one`() {
+    val result = divideString("abc", 1, 'z')
+    assertContentEquals(arrayOf("a", "b", "c"), result)
+  }
+
+  @Test
+  fun `empty string`() {
+    val result = divideString("", 3, 'x')
+    assertContentEquals(emptyArray(), result)
+  }
+}


### PR DESCRIPTION
## Summary
- implement `divideString` algorithm to split strings into fixed-length groups
- add unit tests for `divideString`

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68578569c2a08321b62e0d5b51fdbf56