### PR TITLE
Add longest binary subsequence ≤k solution

### DIFF
--- a/src/main/kotlin/problems/LongestBinarySubsequenceLessThanOrEqualToK.kt
+++ b/src/main/kotlin/problems/LongestBinarySubsequenceLessThanOrEqualToK.kt
@@ -1,0 +1,34 @@
+package problems
+
+/**
+ * 2311. Longest Binary Subsequence Less Than or Equal to K
+ *
+ * Returns the length of the longest subsequence of the given binary string that
+ * forms a binary number less than or equal to [limit].
+ */
+fun longestSubsequence(originalBinaryString: String, limit: Int): Int {
+  var selectedCharacterCount = 0  // length of chosen subsequence
+  var currentNumericValue = 0L    // value of chosen bits so far
+  var currentBitWeight = 1L       // 2⁰ for the least-significant bit
+
+  for (position in originalBinaryString.lastIndex downTo 0) {
+    val currentCharacter = originalBinaryString[position]
+
+    if (currentCharacter == '0') {
+      selectedCharacterCount += 1  // zeros never change the value
+    } else { // currentCharacter == '1'
+      if (currentBitWeight <= limit.toLong() &&
+        currentNumericValue + currentBitWeight <= limit.toLong()
+      ) {
+        currentNumericValue += currentBitWeight
+        selectedCharacterCount += 1
+      }
+    }
+
+    // Prepare weight for the next more-significant bit; stop growing once useless
+    if (currentBitWeight <= limit.toLong()) {
+      currentBitWeight = currentBitWeight shl 1
+    }
+  }
+  return selectedCharacterCount
+}

--- a/src/test/kotlin/problems/LongestBinarySubsequenceLessThanOrEqualToKTest.kt
+++ b/src/test/kotlin/problems/LongestBinarySubsequenceLessThanOrEqualToKTest.kt
@@ -1,0 +1,12 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LongestBinarySubsequenceLessThanOrEqualToKTest {
+  @Test
+  fun `basic examples`() {
+    assertEquals(5, longestSubsequence("1001010", 5))
+    assertEquals(6, longestSubsequence("00101001", 1))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `longestSubsequence` to find longest binary subsequence ≤ k
- add unit tests for the new function

## Testing
- `./gradlew test --no-daemon`
- `./gradlew detekt --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685d03cc0a948321980f4a4843599c97