### PR TITLE
Add largest sum subsequence solution

### DIFF
--- a/src/main/kotlin/problems/FindSubsequenceOfLengthKWithTheLargestSum.kt
+++ b/src/main/kotlin/problems/FindSubsequenceOfLengthKWithTheLargestSum.kt
@@ -1,0 +1,37 @@
+package problems
+
+import java.util.PriorityQueue
+
+/**
+ * Returns a subsequence of length [subsequenceLength] with the largest possible sum.
+ * Elements maintain their relative order from [nums].
+ */
+fun maxSubsequence(nums: IntArray, subsequenceLength: Int): IntArray {
+  data class Element(val value: Int, val originalIndex: Int)
+
+  // Min-heap ordered by value, preferring later indices when values tie
+  val smallestPreferred = PriorityQueue<Element> { a, b ->
+    if (a.value != b.value) {
+      a.value - b.value
+    } else {
+      b.originalIndex - a.originalIndex
+    }
+  }
+
+  // Keep only the best `subsequenceLength` elements
+  for (index in nums.indices) {
+    smallestPreferred.add(Element(nums[index], index))
+    if (smallestPreferred.size > subsequenceLength) {
+      smallestPreferred.poll()
+    }
+  }
+
+  // Extract remaining elements sorted by original index
+  val chosen = smallestPreferred.toTypedArray().sortedBy { it.originalIndex }
+  val result = IntArray(subsequenceLength)
+  for (position in chosen.indices) {
+    result[position] = chosen[position].value
+  }
+
+  return result
+}

--- a/src/test/kotlin/problems/FindSubsequenceOfLengthKWithTheLargestSumTest.kt
+++ b/src/test/kotlin/problems/FindSubsequenceOfLengthKWithTheLargestSumTest.kt
@@ -1,0 +1,27 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+
+class FindSubsequenceOfLengthKWithTheLargestSumTest {
+  @Test
+  fun example1() {
+    val nums = intArrayOf(2, 1, 3, 3)
+    val result = maxSubsequence(nums, 2)
+    assertContentEquals(intArrayOf(3, 3), result)
+  }
+
+  @Test
+  fun example2() {
+    val nums = intArrayOf(-1, -2, 3, 4)
+    val result = maxSubsequence(nums, 3)
+    assertContentEquals(intArrayOf(-1, 3, 4), result)
+  }
+
+  @Test
+  fun example3() {
+    val nums = intArrayOf(3, 4, 3, 3)
+    val result = maxSubsequence(nums, 2)
+    assertContentEquals(intArrayOf(3, 4), result)
+  }
+}


### PR DESCRIPTION
## Summary
- implement `maxSubsequence` for finding a subsequence of length `k` with largest sum
- add unit tests for the new solution

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_685f96c640c48321a82563d21f33f228