### PR TITLE
feat(leetcode): add FindTheOriginalTypedStringI solution

### DIFF
--- a/src/main/kotlin/problems/FindTheOriginalTypedStringI.kt
+++ b/src/main/kotlin/problems/FindTheOriginalTypedStringI.kt
@@ -1,0 +1,20 @@
+package problems
+
+/**
+ * LeetCode 2930. Find the Original Typed String I
+ *
+ * Given the final typed string [word], returns the total number of possible
+ * original strings Alice could have intended to type when she might have held
+ * down at most one key too long.
+ */
+fun possibleStringCount(word: String): Long {
+  if (word.isEmpty()) return 0
+
+  var runCount = 1
+  for (i in 1 until word.length) {
+    if (word[i] != word[i - 1]) {
+      runCount += 1
+    }
+  }
+  return word.length.toLong() - runCount + 1
+}

--- a/src/test/kotlin/problems/FindTheOriginalTypedStringITest.kt
+++ b/src/test/kotlin/problems/FindTheOriginalTypedStringITest.kt
@@ -1,0 +1,21 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class FindTheOriginalTypedStringITest {
+  @Test
+  fun example1() {
+    assertEquals(5L, possibleStringCount("abbcccc"))
+  }
+
+  @Test
+  fun example2() {
+    assertEquals(1L, possibleStringCount("abcd"))
+  }
+
+  @Test
+  fun example3() {
+    assertEquals(4L, possibleStringCount("aaaa"))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `possibleStringCount` to calculate the possible original strings
- add unit tests for the examples

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68635364da648321b76cf3a33ca868ad