### PR TITLE
Add max events attendance solution

### DIFF
--- a/src/main/kotlin/problems/MaximumNumberOfEventsThatCanBeAttended.kt
+++ b/src/main/kotlin/problems/MaximumNumberOfEventsThatCanBeAttended.kt
@@ -1,0 +1,45 @@
+package problems
+
+import java.util.PriorityQueue
+
+/**
+ * LeetCode 1353. Maximum Number of Events That Can Be Attended
+ * https://leetcode.com/problems/maximum-number-of-events-that-can-be-attended/
+ *
+ * Greedy sweep line using a min-heap of end days.
+ * Time Complexity: O(n log n)
+ * Space Complexity: O(n)
+ */
+fun maxEvents(events: Array<IntArray>): Int {
+  // Sort events by start day, then end day
+  events.sortWith(compareBy({ it[0] }, { it[1] }))
+
+  val active = PriorityQueue<Int>() // stores end days
+  var currentDay = 0
+  var index = 0
+  var attended = 0
+
+  // Process days until all events considered and queue empty
+  while (index < events.size || active.isNotEmpty()) {
+    if (active.isEmpty()) {
+      currentDay = events[index][0]
+    }
+
+    while (index < events.size && events[index][0] == currentDay) {
+      active += events[index][1]
+      index++
+    }
+
+    while (active.isNotEmpty() && active.peek() < currentDay) {
+      active.poll()
+    }
+
+    if (active.isNotEmpty()) {
+      active.poll()
+      attended++
+      currentDay++
+    }
+  }
+  return attended
+}
+

--- a/src/test/kotlin/problems/MaximumNumberOfEventsThatCanBeAttendedTest.kt
+++ b/src/test/kotlin/problems/MaximumNumberOfEventsThatCanBeAttendedTest.kt
@@ -1,0 +1,24 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class MaximumNumberOfEventsThatCanBeAttendedTest {
+  @Test
+  fun example1() {
+    val events = arrayOf(intArrayOf(1, 2), intArrayOf(2, 3), intArrayOf(3, 4))
+    assertEquals(3, maxEvents(events))
+  }
+
+  @Test
+  fun example2() {
+    val events = arrayOf(
+      intArrayOf(1, 2),
+      intArrayOf(2, 3),
+      intArrayOf(3, 4),
+      intArrayOf(1, 2)
+    )
+    assertEquals(4, maxEvents(events))
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement greedy sweep-line solution for *Maximum Number of Events That Can Be Attended*
- add unit tests covering sample cases

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_686bab712da483218ecbf6b7bd4ad4c9