### PR TITLE
Add reschedule meetings solution

### DIFF
--- a/src/main/kotlin/problems/RescheduleMeetingsForMaximumFreeTimeI.kt
+++ b/src/main/kotlin/problems/RescheduleMeetingsForMaximumFreeTimeI.kt
@@ -1,0 +1,37 @@
+package problems
+
+fun maxFreeTime(
+  eventTime: Int,
+  k: Int,
+  startTime: IntArray,
+  endTime: IntArray,
+): Int {
+  val n = startTime.size
+
+  // Build all gaps
+  val gaps = mutableListOf<Int>()
+  // before first
+  gaps.add(startTime[0] - 0)
+  // between
+  for (meetingIndex in 1 until n) {
+    gaps.add(startTime[meetingIndex] - endTime[meetingIndex - 1])
+  }
+  // after last
+  gaps.add(eventTime - endTime[n - 1])
+
+  // We can merge (k+1) consecutive gaps into one big interval
+  // So best is sum of any (k+1) contiguous gaps
+  var maxFree = 0
+  var currentSum = 0
+  for (gapIndex in 0 until gaps.size) {
+    currentSum += gaps[gapIndex]
+    if (gapIndex >= k + 1) {
+      currentSum -= gaps[gapIndex - (k + 1)]
+    }
+    if (gapIndex >= k) {
+      maxFree = maxOf(maxFree, currentSum)
+    }
+  }
+
+  return maxFree
+}

--- a/src/test/kotlin/problems/RescheduleMeetingsForMaximumFreeTimeITest.kt
+++ b/src/test/kotlin/problems/RescheduleMeetingsForMaximumFreeTimeITest.kt
@@ -1,0 +1,31 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class RescheduleMeetingsForMaximumFreeTimeITest {
+
+  @Test
+  fun example1() {
+    val startTime = intArrayOf(1, 3)
+    val endTime = intArrayOf(2, 5)
+    val result = maxFreeTime(5, 1, startTime, endTime)
+    assertEquals(2, result)
+  }
+
+  @Test
+  fun example2() {
+    val startTime = intArrayOf(0, 2, 9)
+    val endTime = intArrayOf(1, 4, 10)
+    val result = maxFreeTime(10, 1, startTime, endTime)
+    assertEquals(6, result)
+  }
+
+  @Test
+  fun example3() {
+    val startTime = intArrayOf(0, 1, 2, 3, 4)
+    val endTime = intArrayOf(1, 2, 3, 4, 5)
+    val result = maxFreeTime(5, 2, startTime, endTime)
+    assertEquals(0, result)
+  }
+}


### PR DESCRIPTION
## Summary
- implement algorithm to maximize free time by rescheduling meetings
- add unit tests for examples
- convert `maxFreeTime` to a top-level function

## Testing
- `./gradlew test --no-daemon`
- `./gradlew detekt --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686e0ac6db588321a7dd4d766be76471