### PR TITLE
Add solution for maxFreeTime II

### DIFF
--- a/src/main/kotlin/problems/RescheduleMeetingsForMaximumFreeTimeII.kt
+++ b/src/main/kotlin/problems/RescheduleMeetingsForMaximumFreeTimeII.kt
@@ -1,0 +1,102 @@
+package problems
+
+fun maxFreeTime(
+  eventTime: Int,
+  startTime: IntArray,
+  endTime: IntArray,
+): Int {
+  val meetingCount = startTime.size
+
+  // ---------- 1st pass : find the three largest gaps ----------
+  val largestGapLength = IntArray(3) { -1 }
+  val largestGapIndex = IntArray(3) { -1 }
+
+  fun recordGap(length: Int, index: Int) {
+    when {
+      length > largestGapLength[0] -> {
+        largestGapLength[2] = largestGapLength[1]
+        largestGapIndex[2] = largestGapIndex[1]
+        largestGapLength[1] = largestGapLength[0]
+        largestGapIndex[1] = largestGapIndex[0]
+        largestGapLength[0] = length
+        largestGapIndex[0] = index
+      }
+      length > largestGapLength[1] -> {
+        largestGapLength[2] = largestGapLength[1]
+        largestGapIndex[2] = largestGapIndex[1]
+        largestGapLength[1] = length
+        largestGapIndex[1] = index
+      }
+      length > largestGapLength[2] -> {
+        largestGapLength[2] = length
+        largestGapIndex[2] = index
+      }
+    }
+  }
+
+  var previousEnd = 0
+  var currentGapIndex = 0
+
+  for (meetingIndex in 0 until meetingCount) {
+    val gapBefore = startTime[meetingIndex] - previousEnd // g_j
+    recordGap(gapBefore, currentGapIndex)
+
+    currentGapIndex += 1 // next gap index
+    previousEnd = endTime[meetingIndex]
+  }
+
+  // last gap g_n
+  val gapAfterLast = eventTime - previousEnd
+  recordGap(gapAfterLast, currentGapIndex)
+
+  // ---------- 2nd pass : evaluate every meeting ----------
+  var bestFreeInterval = largestGapLength[0] // baseline
+
+  previousEnd = 0
+  currentGapIndex = 0 // left gap index for meeting 0
+
+  for (meetingIndex in 0 until meetingCount) {
+
+    // adjacent gaps
+    val leftGapLength = startTime[meetingIndex] - previousEnd // g_j
+    val leftGapIndex = currentGapIndex
+
+    val rightGapLength = if (meetingIndex == meetingCount - 1) {
+      eventTime - endTime[meetingIndex] // g_n
+    } else {
+      startTime[meetingIndex + 1] - endTime[meetingIndex] // g_(j+1)
+    }
+
+    val rightGapIndex = currentGapIndex + 1
+
+    // merged gap after removing the meeting
+    val meetingDuration = endTime[meetingIndex] - startTime[meetingIndex]
+    val mergedGapLength = leftGapLength + meetingDuration + rightGapLength
+
+    // largest non-adjacent gap
+    var suitableOtherGap = 0
+    for (rank in 0..2) {
+      val gapIdx = largestGapIndex[rank]
+      if (gapIdx != leftGapIndex && gapIdx != rightGapIndex && gapIdx != -1) {
+        suitableOtherGap = largestGapLength[rank]
+        break
+      }
+    }
+
+    // achievable free interval length with this meeting moved
+    val candidateFreeInterval = if (suitableOtherGap >= meetingDuration) {
+      mergedGapLength // meeting fits elsewhere
+    } else {
+      maxOf(mergedGapLength - meetingDuration, suitableOtherGap)
+    }
+
+    bestFreeInterval = maxOf(bestFreeInterval, candidateFreeInterval)
+
+    // advance to next meeting
+    previousEnd = endTime[meetingIndex]
+    currentGapIndex += 1
+  }
+
+  return bestFreeInterval
+}
+

--- a/src/test/kotlin/problems/RescheduleMeetingsForMaximumFreeTimeIITest.kt
+++ b/src/test/kotlin/problems/RescheduleMeetingsForMaximumFreeTimeIITest.kt
@@ -1,0 +1,40 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class RescheduleMeetingsForMaximumFreeTimeIITest {
+
+  @Test
+  fun example1() {
+    val startTime = intArrayOf(1, 3)
+    val endTime = intArrayOf(2, 5)
+    val result = maxFreeTime(5, startTime, endTime)
+    assertEquals(2, result)
+  }
+
+  @Test
+  fun example2() {
+    val startTime = intArrayOf(0, 7, 9)
+    val endTime = intArrayOf(1, 8, 10)
+    val result = maxFreeTime(10, startTime, endTime)
+    assertEquals(7, result)
+  }
+
+  @Test
+  fun example3() {
+    val startTime = intArrayOf(0, 3, 7, 9)
+    val endTime = intArrayOf(1, 4, 8, 10)
+    val result = maxFreeTime(10, startTime, endTime)
+    assertEquals(6, result)
+  }
+
+  @Test
+  fun example4() {
+    val startTime = intArrayOf(0, 1, 2, 3, 4)
+    val endTime = intArrayOf(1, 2, 3, 4, 5)
+    val result = maxFreeTime(5, startTime, endTime)
+    assertEquals(0, result)
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement `maxFreeTime` for *Reschedule Meetings for Maximum Free Time II*
- add unit tests covering the problem examples

## Testing
- `./gradlew test` *(fails: No matching toolchains found)*
- `./gradlew detekt` *(fails: No matching toolchains found)*

------
https://chatgpt.com/codex/tasks/task_e_686f2dc8ef2083218dd71e67fd79df76