### PR TITLE
Add Count Days Without Meetings

### DIFF
--- a/src/main/kotlin/problems/CountDaysWithoutMeetings.kt
+++ b/src/main/kotlin/problems/CountDaysWithoutMeetings.kt
@@ -1,0 +1,33 @@
+package problems
+
+/**
+ * Count Days Without Meetings
+ *
+ * Given the total number of days and a list of meeting intervals,
+ * return the number of days without any meetings scheduled.
+ */
+fun countDays(totalDays: Int, meetings: Array<IntArray>): Int {
+  if (meetings.isEmpty()) return totalDays
+
+  meetings.sortWith(compareBy<IntArray> { it[0] }.thenBy { it[1] })
+
+  var mergedStart = meetings[0][0]
+  var mergedEnd = meetings[0][1]
+  var occupiedDays = 0L
+
+  for (index in 1 until meetings.size) {
+    val nextStart = meetings[index][0]
+    val nextEnd = meetings[index][1]
+    if (nextStart <= mergedEnd + 1) {
+      if (nextEnd > mergedEnd) mergedEnd = nextEnd
+    } else {
+      occupiedDays += (mergedEnd - mergedStart + 1).toLong()
+      mergedStart = nextStart
+      mergedEnd = nextEnd
+    }
+  }
+  occupiedDays += (mergedEnd - mergedStart + 1).toLong()
+
+  val freeDays = totalDays.toLong() - occupiedDays
+  return freeDays.toInt()
+}

--- a/src/test/kotlin/problems/CountDaysWithoutMeetingsTest.kt
+++ b/src/test/kotlin/problems/CountDaysWithoutMeetingsTest.kt
@@ -1,0 +1,30 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class CountDaysWithoutMeetingsTest {
+  @Test
+  fun example1() {
+    val meetings = arrayOf(intArrayOf(5, 7), intArrayOf(1, 3), intArrayOf(9, 10))
+    assertEquals(2, countDays(10, meetings))
+  }
+
+  @Test
+  fun example2() {
+    val meetings = arrayOf(intArrayOf(2, 4), intArrayOf(1, 3))
+    assertEquals(1, countDays(5, meetings))
+  }
+
+  @Test
+  fun example3() {
+    val meetings = arrayOf(intArrayOf(1, 6))
+    assertEquals(0, countDays(6, meetings))
+  }
+
+  @Test
+  fun noMeetings() {
+    val meetings = emptyArray<IntArray>()
+    assertEquals(7, countDays(7, meetings))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `countDays` as a top level function to compute free days without meetings
- add unit tests for Count Days Without Meetings

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_687082f5988c832188980213c7238566