### PR TITLE
Add matchPlayersAndTrainers solution

### DIFF
--- a/src/main/kotlin/problems/MatchPlayersAndTrainers.kt
+++ b/src/main/kotlin/problems/MatchPlayersAndTrainers.kt
@@ -1,0 +1,25 @@
+package problems
+
+fun matchPlayersAndTrainers(players: IntArray, trainers: IntArray): Int {
+  players.sort()
+  trainers.sort()
+
+  var playerIndex = 0
+  var trainerIndex = 0
+  var totalMatches = 0
+
+  while (playerIndex < players.size && trainerIndex < trainers.size) {
+    val ability = players[playerIndex]
+    val capacity = trainers[trainerIndex]
+
+    if (ability <= capacity) {
+      totalMatches += 1
+      playerIndex += 1
+      trainerIndex += 1
+    } else {
+      trainerIndex += 1
+    }
+  }
+
+  return totalMatches
+}

--- a/src/test/kotlin/problems/MatchPlayersAndTrainersTest.kt
+++ b/src/test/kotlin/problems/MatchPlayersAndTrainersTest.kt
@@ -1,0 +1,20 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class MatchPlayersAndTrainersTest {
+  @Test
+  fun example1() {
+    val players = intArrayOf(4, 7, 9)
+    val trainers = intArrayOf(8, 2, 5, 8)
+    assertEquals(2, matchPlayersAndTrainers(players, trainers))
+  }
+
+  @Test
+  fun example2() {
+    val players = intArrayOf(1, 1, 1)
+    val trainers = intArrayOf(10)
+    assertEquals(1, matchPlayersAndTrainers(players, trainers))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `matchPlayersAndTrainers` problem solution
- add unit tests for the problem

## Testing
- `./gradlew test --no-daemon`
- `./gradlew detekt --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687341a4ab6883218c859b6894eb9607