### PR TITLE
feat(leetcode): add word validity check

### DIFF
--- a/src/main/kotlin/leetcode/ValidWord.kt
+++ b/src/main/kotlin/leetcode/ValidWord.kt
@@ -1,0 +1,32 @@
+package leetcode
+
+fun isValid(word: String): Boolean {
+  if (word.length < 3) return false
+
+  val vowels = setOf('a', 'e', 'i', 'o', 'u')
+  var hasVowel = false
+  var hasConsonant = false
+
+  for (symbol in word) {
+    when {
+      symbol.isDigit() -> {
+        // digits are allowed but do not affect vowel/consonant flags
+      }
+      symbol.isLetter() -> {
+        val lowerCaseSymbol = symbol.lowercaseChar()
+        if (lowerCaseSymbol in vowels) {
+          hasVowel = true
+        } else {
+          hasConsonant = true
+        }
+      }
+      else -> return false // invalid character detected
+    }
+  }
+
+  return hasVowel && hasConsonant
+}
+
+class Solution {
+  fun isValid(word: String): Boolean = leetcode.isValid(word)
+}

--- a/src/test/kotlin/problems/ValidWordTest.kt
+++ b/src/test/kotlin/problems/ValidWordTest.kt
@@ -1,0 +1,22 @@
+import leetcode.Solution
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ValidWordTest {
+  private val solution = Solution()
+
+  @Test
+  fun testIsValidWord() {
+    val testCases = listOf(
+      "234Adas" to true,
+      "b3" to false,
+      "AcA" to true,
+      "jav!a" to false,
+      "cake" to true
+    )
+
+    for ((input, expected) in testCases) {
+      assertEquals(expected, solution.isValid(input))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `isValid` as a top-level function in new `leetcode` package
- add tests for word validity criteria

## Testing
- `./gradlew test --no-daemon`
- `./gradlew detekt --no-daemon --auto-correct`


------
https://chatgpt.com/codex/tasks/task_e_6875ff2134b88321a198c35d8f07f1d1