### PR TITLE
Add solution for removing subfolders

### DIFF
--- a/src/main/kotlin/problems/RemoveSubFoldersFromTheFileSystem.kt
+++ b/src/main/kotlin/problems/RemoveSubFoldersFromTheFileSystem.kt
@@ -1,0 +1,17 @@
+package problems
+
+fun removeSubfolders(folder: Array<String>): List<String> {
+  folder.sort()
+  val keptFolders = ArrayList<String>()
+  var lastKept: String? = null
+
+  for (path in folder) {
+    val prefix = if (lastKept == null) null else "$lastKept/"
+    if (lastKept == null || !path.startsWith(prefix!!)) {
+      keptFolders.add(path)
+      lastKept = path
+    }
+  }
+  return keptFolders
+}
+

--- a/src/test/kotlin/problems/RemoveSubFoldersFromTheFileSystemTest.kt
+++ b/src/test/kotlin/problems/RemoveSubFoldersFromTheFileSystemTest.kt
@@ -1,0 +1,27 @@
+package problems
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RemoveSubFoldersFromTheFileSystemTest {
+  @Test
+  fun example1() {
+    val folder = arrayOf("/a","/a/b","/c/d","/c/d/e","/c/f")
+    val expected = listOf("/a","/c/d","/c/f")
+    assertEquals(expected, removeSubfolders(folder))
+  }
+
+  @Test
+  fun example2() {
+    val folder = arrayOf("/a","/a/b/c","/a/b/d")
+    val expected = listOf("/a")
+    assertEquals(expected, removeSubfolders(folder))
+  }
+
+  @Test
+  fun noSubfolders() {
+    val folder = arrayOf("/a","/b","/c")
+    val expected = listOf("/a","/b","/c")
+    assertEquals(expected, removeSubfolders(folder))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `removeSubfolders` using lexicographic sort
- test removing subfolders in filesystem

## Testing
- `./gradlew detekt`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_687ba2cf0a0c83218afd599a5541502a