### PR TITLE
feat(problems): add unique subarray sum after deletion

### DIFF
--- a/src/main/kotlin/problems/MaximumUniqueSubarraySumAfterDeletion.kt
+++ b/src/main/kotlin/problems/MaximumUniqueSubarraySumAfterDeletion.kt
@@ -1,0 +1,28 @@
+package problems
+
+import java.util.BitSet
+
+fun maxSum(nums: IntArray): Long {
+  val positiveSeen = BitSet()
+
+  var distinctPositiveSum = 0L
+  var foundZero = false
+  var bestNegative = Int.MIN_VALUE
+
+  for (v in nums) {
+    when {
+      v > 0 -> if (!positiveSeen.get(v)) {
+        positiveSeen.set(v)
+        distinctPositiveSum += v
+      }
+      v == 0 -> foundZero = true
+      else -> if (v > bestNegative) bestNegative = v
+    }
+  }
+
+  return when {
+    distinctPositiveSum > 0L -> distinctPositiveSum
+    foundZero -> 0L
+    else -> bestNegative.toLong()
+  }
+}

--- a/src/test/kotlin/problems/MaximumUniqueSubarraySumAfterDeletionTest.kt
+++ b/src/test/kotlin/problems/MaximumUniqueSubarraySumAfterDeletionTest.kt
@@ -1,0 +1,24 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class MaximumUniqueSubarraySumAfterDeletionTest {
+  @Test
+  fun example1() {
+    val nums = intArrayOf(1, 2, 3, 4, 5)
+    assertEquals(15L, maxSum(nums))
+  }
+
+  @Test
+  fun example2() {
+    val nums = intArrayOf(1, 1, 0, 1, 1)
+    assertEquals(1L, maxSum(nums))
+  }
+
+  @Test
+  fun example3() {
+    val nums = intArrayOf(1, 2, -1, -2, 1, 0, -1)
+    assertEquals(3L, maxSum(nums))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `maxSum` for Maximum Unique Subarray Sum After Deletion
- add tests for the problem

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.9.0'] not found)*
- `gradle detekt` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.9.0'] not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883298ab068832183eb654378870366