### PR TITLE
Add countMaxOrSubsets solution

### DIFF
--- a/src/main/kotlin/problems/CountMaxOrSubsets.kt
+++ b/src/main/kotlin/problems/CountMaxOrSubsets.kt
@@ -1,0 +1,40 @@
+package problems
+
+/**
+ * Returns the number of non-empty subsets of [nums] whose bitwise OR is maximum.
+ * The maximum OR is the bitwise OR of all elements in the array.
+ */
+fun countMaxOrSubsets(nums: IntArray): Int {
+  val maximumOr = nums.fold(0) { acc, element -> acc or element }
+  val elementCount = nums.size
+
+  // numberOfFreeChoices[r] = 2^r, used when we've already hit maximumOr
+  val numberOfFreeChoices = LongArray(elementCount + 1).apply {
+    this[0] = 1L
+    for (remaining in 1..elementCount) this[remaining] = this[remaining - 1] shl 1
+  }
+
+  // Memo key packs (nextIndex, currentOr)
+  val memoizedCounts = HashMap<Long, Long>()
+
+  fun countSubsetsReachingMaximumOr(nextIndex: Int, currentOr: Int): Long {
+    if (currentOr == maximumOr) {
+      // Any subset of the remaining tail keeps OR == maximumOr
+      return numberOfFreeChoices[elementCount - nextIndex]
+    }
+    if (nextIndex == elementCount) return 0L
+
+    val stateKey = (nextIndex.toLong() shl 32) or (currentOr.toLong() and 0xffffffffL)
+    memoizedCounts[stateKey]?.let { return it }
+
+    val skipCurrent = countSubsetsReachingMaximumOr(nextIndex + 1, currentOr)
+    val takeCurrent = countSubsetsReachingMaximumOr(nextIndex + 1, currentOr or nums[nextIndex])
+
+    val totalForState = skipCurrent + takeCurrent
+    memoizedCounts[stateKey] = totalForState
+    return totalForState
+  }
+
+  return countSubsetsReachingMaximumOr(0, 0).toInt()
+}
+

--- a/src/test/kotlin/problems/CountMaxOrSubsetsTest.kt
+++ b/src/test/kotlin/problems/CountMaxOrSubsetsTest.kt
@@ -1,0 +1,30 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class CountMaxOrSubsetsTest {
+  @Test
+  fun example1() {
+    val nums = intArrayOf(3, 1)
+    assertEquals(2, countMaxOrSubsets(nums))
+  }
+
+  @Test
+  fun example2() {
+    val nums = intArrayOf(2, 2, 2)
+    assertEquals(7, countMaxOrSubsets(nums))
+  }
+
+  @Test
+  fun example3() {
+    val nums = intArrayOf(3, 2, 1, 5)
+    assertEquals(6, countMaxOrSubsets(nums))
+  }
+
+  @Test
+  fun singleElement() {
+    val nums = intArrayOf(5)
+    assertEquals(1, countMaxOrSubsets(nums))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `countMaxOrSubsets` to count subsets with the maximum bitwise OR
- add tests for the new function

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew detekt` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6887181bb34083218fa28e3b8943fa05