### PR TITLE
Add Pascal Triangle solution

### DIFF
--- a/src/main/kotlin/problems/PascalTriangle.kt
+++ b/src/main/kotlin/problems/PascalTriangle.kt
@@ -1,0 +1,13 @@
+package problems
+
+fun generate(numRows: Int): List<List<Int>> {
+  val triangle = mutableListOf<List<Int>>()
+  for (rowIndex in 0 until numRows) {
+    val row = MutableList(rowIndex + 1) { 1 }
+    for (col in 1 until rowIndex) {
+      row[col] = triangle[rowIndex - 1][col - 1] + triangle[rowIndex - 1][col]
+    }
+    triangle.add(row)
+  }
+  return triangle
+}

--- a/src/test/kotlin/problems/PascalTriangleTest.kt
+++ b/src/test/kotlin/problems/PascalTriangleTest.kt
@@ -1,0 +1,19 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class PascalTriangleTest {
+  @Test
+  fun testGenerate() {
+    val expected = listOf(
+      listOf(1),
+      listOf(1, 1),
+      listOf(1, 2, 1),
+      listOf(1, 3, 3, 1),
+      listOf(1, 4, 6, 4, 1)
+    )
+    assertEquals(expected, generate(5))
+    assertEquals(listOf(listOf(1)), generate(1))
+  }
+}


### PR DESCRIPTION
## Summary
- implement Pascal Triangle generator
- add unit test for Pascal Triangle

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_688cae02fa608321b341280cbcc159a1