### PR TITLE
feat(problems): add total fruit solution

### DIFF
--- a/src/main/kotlin/problems/TotalFruit.kt
+++ b/src/main/kotlin/problems/TotalFruit.kt
@@ -1,0 +1,31 @@
+package problems
+
+fun totalFruit(fruits: IntArray): Int {
+  val basketCounts = mutableMapOf<Int, Int>()   // fruitType → occurrences in current window
+  var leftPointer = 0
+  var maximumFruits = 0
+
+  for (rightPointer in fruits.indices) {
+    // Add current tree’s fruit to the window
+    val currentFruit = fruits[rightPointer]
+    basketCounts[currentFruit] = (basketCounts[currentFruit] ?: 0) + 1
+
+    // Shrink window until ≤ 2 distinct fruit types remain
+    while (basketCounts.size > 2) {
+      val fruitAtLeft = fruits[leftPointer]
+      basketCounts[fruitAtLeft] = basketCounts.getValue(fruitAtLeft) - 1
+      if (basketCounts.getValue(fruitAtLeft) == 0) {
+        basketCounts.remove(fruitAtLeft)
+      }
+      leftPointer += 1
+    }
+
+    // Record best window so far
+    val currentWindowSize = rightPointer - leftPointer + 1
+    if (currentWindowSize > maximumFruits) {
+      maximumFruits = currentWindowSize
+    }
+  }
+
+  return maximumFruits
+}

--- a/src/test/kotlin/problems/TotalFruitTest.kt
+++ b/src/test/kotlin/problems/TotalFruitTest.kt
@@ -1,0 +1,30 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class TotalFruitTest {
+  @Test
+  fun example1() {
+    val fruits = intArrayOf(1, 2, 1)
+    assertEquals(3, totalFruit(fruits))
+  }
+
+  @Test
+  fun example2() {
+    val fruits = intArrayOf(0, 1, 2, 2)
+    assertEquals(3, totalFruit(fruits))
+  }
+
+  @Test
+  fun example3() {
+    val fruits = intArrayOf(1, 2, 3, 2, 2)
+    assertEquals(4, totalFruit(fruits))
+  }
+
+  @Test
+  fun singleFruit() {
+    val fruits = intArrayOf(0)
+    assertEquals(1, totalFruit(fruits))
+  }
+}


### PR DESCRIPTION
## Summary
- add sliding window solution for Fruit Into Baskets
- cover typical scenarios for total fruit

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_6890c401cbe08321af207d11f2a6198c