### PR TITLE
feat(problems): add soup servings solution

### DIFF
--- a/src/main/kotlin/problems/soupservings/SoupServings.kt
+++ b/src/main/kotlin/problems/soupservings/SoupServings.kt
@@ -1,0 +1,34 @@
+package problems.soupservings
+
+class Solution {
+  private lateinit var memo: Array<DoubleArray>
+
+  fun soupServings(n: Int): Double {
+    // For large n, the probability approaches 1 within 1e-5
+    if (n >= 4800) return 1.0
+
+    val units = (n + 24) / 25  // ceil(n / 25)
+    memo = Array(units + 1) { DoubleArray(units + 1) { -1.0 } }
+    return probabilityAEmptiesFirst(units, units)
+  }
+
+  private fun probabilityAEmptiesFirst(aUnits: Int, bUnits: Int): Double {
+    if (aUnits <= 0 && bUnits <= 0) return 0.5
+    if (aUnits <= 0) return 1.0
+    if (bUnits <= 0) return 0.0
+
+    if (memo[aUnits][bUnits] >= 0.0) return memo[aUnits][bUnits]
+
+    val result =
+      0.25 * (
+        probabilityAEmptiesFirst(aUnits - 4, bUnits) +
+          probabilityAEmptiesFirst(aUnits - 3, bUnits - 1) +
+          probabilityAEmptiesFirst(aUnits - 2, bUnits - 2) +
+          probabilityAEmptiesFirst(aUnits - 1, bUnits - 3)
+        )
+
+    memo[aUnits][bUnits] = result
+    return result
+  }
+}
+

--- a/src/test/kotlin/problems/soupservings/SoupServingsTest.kt
+++ b/src/test/kotlin/problems/soupservings/SoupServingsTest.kt
@@ -1,0 +1,15 @@
+package problems.soupservings
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class SoupServingsTest {
+  @Test
+  fun testSoupServings() {
+    val solution = Solution()
+    assertEquals(0.625, solution.soupServings(50))
+    assertEquals(0.71875, solution.soupServings(100))
+    assertEquals(1.0, solution.soupServings(660295675))
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement Soup Servings probability with memoized recursion
- add unit tests for Soup Servings scenarios

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_6895e9e451a08321af364438958687d4