### PR TITLE
feat(leetcode): add maximum 69 number solution

### DIFF
--- a/src/main/kotlin/problems/maximum69number/Maximum69Number.kt
+++ b/src/main/kotlin/problems/maximum69number/Maximum69Number.kt
@@ -1,0 +1,14 @@
+package problems.maximum69number
+
+class Solution {
+  fun maximum69Number(num: Int): Int {
+    val digits = num.toString().toCharArray()
+    for (position in digits.indices) {
+      if (digits[position] == '6') {
+        digits[position] = '9'
+        return String(digits).toInt()
+      }
+    }
+    return num
+  }
+}

--- a/src/test/kotlin/problems/maximum69number/Maximum69NumberTest.kt
+++ b/src/test/kotlin/problems/maximum69number/Maximum69NumberTest.kt
@@ -1,0 +1,23 @@
+package problems.maximum69number
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class Maximum69NumberTest {
+  private val solution = Solution()
+
+  @Test
+  fun providedExample() {
+    assertEquals(9969, solution.maximum69Number(9669))
+  }
+
+  @Test
+  fun alreadyMax() {
+    assertEquals(9999, solution.maximum69Number(9999))
+  }
+
+  @Test
+  fun singleDigit() {
+    assertEquals(9, solution.maximum69Number(6))
+  }
+}


### PR DESCRIPTION
## Summary
- add `Solution` class implementing Maximum 69 Number logic
- cover edge cases for maximizing digit swap

## Testing
- `./gradlew test`
- `./gradlew detekt`

------
https://chatgpt.com/codex/tasks/task_e_68a0a1db79308321b2cd44b8f4eb862f