### PR TITLE
feat: add number of submatrices with all ones solution

### DIFF
--- a/src/main/kotlin/problems/NumberOfSubmatricesWithAllOnes.kt
+++ b/src/main/kotlin/problems/NumberOfSubmatricesWithAllOnes.kt
@@ -1,0 +1,54 @@
+package problems
+
+import java.util.ArrayDeque
+
+data class Bar(val height: Int, val widthCount: Int)
+
+fun numSubmat(mat: Array<IntArray>): Int {
+  val rowCount = mat.size
+  val columnCount = mat[0].size
+  val consecutiveOnesHeight = IntArray(columnCount)
+  var totalSubmatrices = 0L
+
+  for (rowIndex in 0 until rowCount) {
+    // 1) Build histogram heights for this base row
+    for (columnIndex in 0 until columnCount) {
+      consecutiveOnesHeight[columnIndex] =
+        if (mat[rowIndex][columnIndex] == 1)
+          consecutiveOnesHeight[columnIndex] + 1
+        else
+          0
+    }
+
+    // 2) Monotonic stack to count all-ones submatrices with bottom at rowIndex
+    val stack = ArrayDeque<Bar>()
+    var runningTotalForRow = 0L
+
+    for (columnIndex in 0 until columnCount) {
+      var widthAccumulated = 1
+      var currentHeight = consecutiveOnesHeight[columnIndex]
+
+      // Merge taller/equal bars to maintain increasing heights
+      while (stack.isNotEmpty() && stack.peekLast().height >= currentHeight) {
+        val removed = stack.removeLast()
+        runningTotalForRow -= removed.height.toLong() * removed.widthCount.toLong()
+        widthAccumulated += removed.widthCount
+      }
+
+      if (currentHeight > 0) {
+        runningTotalForRow += currentHeight.toLong() * widthAccumulated.toLong()
+        stack.addLast(Bar(currentHeight, widthAccumulated))
+      } else {
+        // Height is zero: nothing contributes at this column
+        stack.clear() // optional (runningTotalForRow already reflects zero-height)
+        runningTotalForRow = 0L
+      }
+
+      totalSubmatrices += runningTotalForRow
+    }
+  }
+
+  // Given constraints, this fits in Int, but keep it safe:
+  return totalSubmatrices.toInt()
+}
+

--- a/src/test/kotlin/problems/NumberOfSubmatricesWithAllOnesTest.kt
+++ b/src/test/kotlin/problems/NumberOfSubmatricesWithAllOnesTest.kt
@@ -1,0 +1,24 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class NumberOfSubmatricesWithAllOnesTest {
+  @Test
+  fun testNumSubmat() {
+    val mat1 = arrayOf(
+      intArrayOf(1, 0, 1),
+      intArrayOf(1, 1, 0),
+      intArrayOf(1, 1, 0)
+    )
+    assertEquals(13, numSubmat(mat1))
+
+    val mat2 = arrayOf(
+      intArrayOf(0, 1, 1, 0),
+      intArrayOf(0, 1, 1, 1),
+      intArrayOf(1, 1, 1, 0)
+    )
+    assertEquals(24, numSubmat(mat2))
+  }
+}
+


### PR DESCRIPTION
## Summary
- add solution for counting submatrices with all ones using histogram and monotonic stack
- add tests for the submatrix counting solution

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68a6bd2e3e7883218e25da3de9d78cd5