### PR TITLE
feat(problems): add minimum area rectangle covering ones

### DIFF
--- a/src/main/kotlin/problems/minimumarearectanglecoveringallones/MinimumAreaRectangleCoveringAllOnes.kt
+++ b/src/main/kotlin/problems/minimumarearectanglecoveringallones/MinimumAreaRectangleCoveringAllOnes.kt
@@ -1,0 +1,28 @@
+package problems.minimumarearectanglecoveringallones
+
+class Solution {
+  fun minimumArea(grid: Array<IntArray>): Int {
+    var top = Int.MAX_VALUE
+    var bottom = Int.MIN_VALUE
+    var left = Int.MAX_VALUE
+    var right = Int.MIN_VALUE
+
+    // Find the boundaries of 1's in the grid
+    for (i in grid.indices) {
+      for (j in grid[i].indices) {
+        if (grid[i][j] == 1) {
+          top = minOf(top, i)
+          bottom = maxOf(bottom, i)
+          left = minOf(left, j)
+          right = maxOf(right, j)
+        }
+      }
+    }
+
+    // Calculate the area of the rectangle
+    val height = bottom - top + 1
+    val width = right - left + 1
+    return height * width
+  }
+}
+

--- a/src/test/kotlin/problems/MinimumAreaRectangleCoveringAllOnesTest.kt
+++ b/src/test/kotlin/problems/MinimumAreaRectangleCoveringAllOnesTest.kt
@@ -1,0 +1,25 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import problems.minimumarearectanglecoveringallones.Solution
+
+class MinimumAreaRectangleCoveringAllOnesTest {
+  @Test
+  fun testMinimumArea() {
+    val solution = Solution()
+    val grid1 = arrayOf(
+      intArrayOf(0, 0, 0),
+      intArrayOf(0, 1, 0),
+      intArrayOf(0, 0, 0)
+    )
+    assertEquals(1, solution.minimumArea(grid1))
+
+    val grid2 = arrayOf(
+      intArrayOf(0, 1, 0),
+      intArrayOf(1, 0, 0)
+    )
+    assertEquals(4, solution.minimumArea(grid2))
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement minimumArea to compute bounding rectangle area of ones
- add unit tests for minimum area rectangle implementation

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68a814382f588321b490bda06e066955