### PR TITLE
feat(leetcode): add diagonal traverse solution

### DIFF
--- a/src/main/kotlin/problems/FindDiagonalOrder.kt
+++ b/src/main/kotlin/problems/FindDiagonalOrder.kt
@@ -1,0 +1,48 @@
+package problems
+
+fun findDiagonalOrder(mat: Array<IntArray>): IntArray {
+  val rowCount = mat.size
+  val colCount = mat[0].size
+  val totalCount = rowCount * colCount
+  val traversal = IntArray(totalCount)
+
+  var rowIndex = 0
+  var colIndex = 0
+  var movingUp = true
+  var writeIndex = 0
+
+  while (writeIndex < totalCount) {
+    traversal[writeIndex] = mat[rowIndex][colIndex]
+    writeIndex += 1
+
+    if (movingUp) {
+      val atTop = rowIndex == 0
+      val atRight = colIndex == colCount - 1
+      if (atRight) {
+        rowIndex += 1
+        movingUp = false
+      } else if (atTop) {
+        colIndex += 1
+        movingUp = false
+      } else {
+        rowIndex -= 1
+        colIndex += 1
+      }
+    } else {
+      val atBottom = rowIndex == rowCount - 1
+      val atLeft = colIndex == 0
+      if (atBottom) {
+        colIndex += 1
+        movingUp = true
+      } else if (atLeft) {
+        rowIndex += 1
+        movingUp = true
+      } else {
+        rowIndex += 1
+        colIndex -= 1
+      }
+    }
+  }
+
+  return traversal
+}

--- a/src/test/kotlin/problems/FindDiagonalOrderTest.kt
+++ b/src/test/kotlin/problems/FindDiagonalOrderTest.kt
@@ -1,0 +1,29 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+
+class FindDiagonalOrderTest {
+  @Test
+  fun example1() {
+    val input = arrayOf(
+      intArrayOf(1, 2, 3),
+      intArrayOf(4, 5, 6),
+      intArrayOf(7, 8, 9)
+    )
+    val expected = intArrayOf(1, 2, 4, 7, 5, 3, 6, 8, 9)
+
+    assertContentEquals(expected, findDiagonalOrder(input))
+  }
+
+  @Test
+  fun example2() {
+    val input = arrayOf(
+      intArrayOf(1, 2),
+      intArrayOf(3, 4)
+    )
+    val expected = intArrayOf(1, 2, 3, 4)
+
+    assertContentEquals(expected, findDiagonalOrder(input))
+  }
+}


### PR DESCRIPTION
## Summary
- implement `findDiagonalOrder` for diagonal matrix traversal
- add unit tests for diagonal traversal examples

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68abff7d53708321960ac107daf5c813