### PR TITLE
feat(problems): add area of max diagonal solution

### DIFF
--- a/src/main/kotlin/problems/areaofmaxdiagonal/AreaOfMaxDiagonal.kt
+++ b/src/main/kotlin/problems/areaofmaxdiagonal/AreaOfMaxDiagonal.kt
@@ -1,0 +1,24 @@
+package problems.areaofmaxdiagonal
+
+class Solution {
+  fun areaOfMaxDiagonal(dimensions: Array<IntArray>): Int {
+    var bestDiagonalSquared = -1
+    var bestArea = 0
+
+    for (sizePair in dimensions) {
+      val length = sizePair[0]
+      val width = sizePair[1]
+
+      val diagonalSquared = length * length + width * width
+      val area = length * width
+
+      if (diagonalSquared > bestDiagonalSquared ||
+        (diagonalSquared == bestDiagonalSquared && area > bestArea)
+      ) {
+        bestDiagonalSquared = diagonalSquared
+        bestArea = area
+      }
+    }
+    return bestArea
+  }
+}

--- a/src/test/kotlin/problems/areaofmaxdiagonal/AreaOfMaxDiagonalTest.kt
+++ b/src/test/kotlin/problems/areaofmaxdiagonal/AreaOfMaxDiagonalTest.kt
@@ -1,0 +1,26 @@
+package problems.areaofmaxdiagonal
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class AreaOfMaxDiagonalTest {
+  private val solution = Solution()
+
+  @Test
+  fun `example case`() {
+    val dimensions = arrayOf(
+      intArrayOf(9, 3),
+      intArrayOf(8, 6)
+    )
+    assertEquals(48, solution.areaOfMaxDiagonal(dimensions))
+  }
+
+  @Test
+  fun `tie on diagonal chooses larger area`() {
+    val dimensions = arrayOf(
+      intArrayOf(3, 4),
+      intArrayOf(4, 3)
+    )
+    assertEquals(12, solution.areaOfMaxDiagonal(dimensions))
+  }
+}


### PR DESCRIPTION
## Summary
- add solution to compute maximal diagonal area
- cover tie and standard scenarios with tests

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68ad7a7cd82883218057841403f06321