### PR TITLE
feat(problems): add valid sudoku solver

### DIFF
--- a/src/main/kotlin/problems/validsudoku/ValidSudoku.kt
+++ b/src/main/kotlin/problems/validsudoku/ValidSudoku.kt
@@ -1,0 +1,32 @@
+package problems.validsudoku
+
+class Solution {
+  fun isValidSudoku(board: Array<CharArray>): Boolean {
+    val rowUsed = IntArray(9)
+    val columnUsed = IntArray(9)
+    val boxUsed = IntArray(9)
+
+    for (rowIndex in 0 until 9) {
+      for (columnIndex in 0 until 9) {
+        val cell = board[rowIndex][columnIndex]
+        if (cell == '.') continue
+
+        val digitIndex = cell - '1'          // 0..8
+        if (digitIndex !in 0..8) return false // guard against invalid chars
+
+        val bit = 1 shl digitIndex
+        val boxIndex = (rowIndex / 3) * 3 + (columnIndex / 3)
+
+        val seenInRow = (rowUsed[rowIndex] and bit) != 0
+        val seenInColumn = (columnUsed[columnIndex] and bit) != 0
+        val seenInBox = (boxUsed[boxIndex] and bit) != 0
+        if (seenInRow || seenInColumn || seenInBox) return false
+
+        rowUsed[rowIndex] = rowUsed[rowIndex] or bit
+        columnUsed[columnIndex] = columnUsed[columnIndex] or bit
+        boxUsed[boxIndex] = boxUsed[boxIndex] or bit
+      }
+    }
+    return true
+  }
+}

--- a/src/test/kotlin/problems/validsudoku/ValidSudokuTest.kt
+++ b/src/test/kotlin/problems/validsudoku/ValidSudokuTest.kt
@@ -1,0 +1,40 @@
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import problems.validsudoku.Solution
+
+class ValidSudokuTest {
+  private val solution = Solution()
+
+  @Test
+  fun testValidBoard() {
+    val board = arrayOf(
+      charArrayOf('5','3','.','.','7','.','.','.','.'),
+      charArrayOf('6','.','.','1','9','5','.','.','.'),
+      charArrayOf('.','9','8','.','.','.','.','6','.'),
+      charArrayOf('8','.','.','.','6','.','.','.','3'),
+      charArrayOf('4','.','.','8','.','3','.','.','1'),
+      charArrayOf('7','.','.','.','2','.','.','.','6'),
+      charArrayOf('.','6','.','.','.','.','2','8','.'),
+      charArrayOf('.','.','.','4','1','9','.','.','5'),
+      charArrayOf('.','.','.','.','8','.','.','7','9')
+    )
+    assertTrue(solution.isValidSudoku(board))
+  }
+
+  @Test
+  fun testInvalidBoard() {
+    val board = arrayOf(
+      charArrayOf('8','3','.','.','7','.','.','.','.'),
+      charArrayOf('6','.','.','1','9','5','.','.','.'),
+      charArrayOf('.','9','8','.','.','.','.','6','.'),
+      charArrayOf('8','.','.','.','6','.','.','.','3'),
+      charArrayOf('4','.','.','8','.','3','.','.','1'),
+      charArrayOf('7','.','.','.','2','.','.','.','6'),
+      charArrayOf('.','6','.','.','.','.','2','8','.'),
+      charArrayOf('.','.','.','4','1','9','.','.','5'),
+      charArrayOf('.','.','.','.','8','.','.','7','9')
+    )
+    assertFalse(solution.isValidSudoku(board))
+  }
+}


### PR DESCRIPTION
## Summary
- implement Sudoku validity checker using bitmasks
- add unit tests for valid and invalid Sudoku boards

## Testing
- `./gradlew --no-daemon --console=plain test --tests "ValidSudokuTest"` *(fails to complete; see warning)*
- `./gradlew --no-daemon --console=plain detekt` *(fails to complete; see warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b27bf82d5c832187238a06b641e581