### PR TITLE
feat(leetcode): add maximum average pass ratio solution

### DIFF
--- a/src/main/kotlin/problems/MaximumAveragePassRatio.kt
+++ b/src/main/kotlin/problems/MaximumAveragePassRatio.kt
@@ -1,0 +1,42 @@
+package problems
+
+import java.util.PriorityQueue
+import kotlin.Comparator
+
+private data class ClassState(var passed: Int, var total: Int) {
+  fun gain(): Double {
+    val p = passed.toDouble()
+    val t = total.toDouble()
+    return (p + 1.0) / (t + 1.0) - p / t
+  }
+
+  fun ratio(): Double = passed.toDouble() / total.toDouble()
+}
+
+fun maxAverageRatio(classes: Array<IntArray>, extraStudents: Int): Double {
+  val byGainDesc = Comparator<ClassState> { a, b ->
+    val diff = b.gain().compareTo(a.gain())
+    if (diff != 0) diff else 0
+  }
+  val classHeap = PriorityQueue(byGainDesc)
+
+  for (entry in classes) {
+    classHeap.add(ClassState(entry[0], entry[1]))
+  }
+
+  var remaining = extraStudents
+  while (remaining > 0) {
+    val best = classHeap.poll()
+    best.passed += 1
+    best.total += 1
+    classHeap.add(best)
+    remaining -= 1
+  }
+
+  var sumOfRatios = 0.0
+  for (state in classHeap) {
+    sumOfRatios += state.ratio()
+  }
+  return sumOfRatios / classes.size.toDouble()
+}
+

--- a/src/test/kotlin/problems/MaxAverageRatioTest.kt
+++ b/src/test/kotlin/problems/MaxAverageRatioTest.kt
@@ -1,0 +1,21 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class MaxAverageRatioTest {
+  @Test
+  fun example1() {
+    val classes = arrayOf(intArrayOf(1, 2), intArrayOf(3, 5), intArrayOf(2, 2))
+    val extra = 2
+    assertEquals(0.78333, maxAverageRatio(classes, extra), 1e-5)
+  }
+
+  @Test
+  fun example2() {
+    val classes = arrayOf(intArrayOf(2, 4), intArrayOf(3, 9), intArrayOf(4, 5), intArrayOf(2, 10))
+    val extra = 4
+    assertEquals(0.53485, maxAverageRatio(classes, extra), 1e-5)
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement greedy maxAverageRatio solution using priority queue
- add tests for sample scenarios

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68b5860244e08321ad7a12fc4759308c