### PR TITLE
feat(problems): add sort vowels function

### DIFF
--- a/src/main/kotlin/problems/SortVowels.kt
+++ b/src/main/kotlin/problems/SortVowels.kt
@@ -1,0 +1,30 @@
+package problems
+
+fun sortVowels(s: String): String {
+  fun isVowel(ch: Char): Boolean {
+    return when (ch) {
+      'a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U' -> true
+      else -> false
+    }
+  }
+
+  val vowels = mutableListOf<Char>()
+  for (character in s) {
+    if (isVowel(character)) vowels.add(character)
+  }
+  vowels.sort()
+
+  val resultChars = CharArray(s.length)
+  var vowelIndex = 0
+  for (position in s.indices) {
+    val ch = s[position]
+    if (isVowel(ch)) {
+      resultChars[position] = vowels[vowelIndex]
+      vowelIndex += 1
+    } else {
+      resultChars[position] = ch
+    }
+  }
+  return String(resultChars)
+}
+


### PR DESCRIPTION
## Summary
- add top-level `sortVowels` function to reorder vowels in ASCII order

## Testing
- `./gradlew test`
- `./gradlew detekt`


------
https://chatgpt.com/codex/tasks/task_e_68c2d240429c8321b6a57294737fc683