### PR TITLE
feat: add successful pairs spells and potions solution

### DIFF
--- a/src/main/kotlin/problems/SuccessfulPairsOfSpellsAndPotions.kt
+++ b/src/main/kotlin/problems/SuccessfulPairsOfSpellsAndPotions.kt
@@ -1,0 +1,39 @@
+fun successfulPairs(spells: IntArray, potions: IntArray, success: Long): IntArray {
+  potions.sort()
+
+  val result = IntArray(spells.size)
+  val totalPotions = potions.size
+
+  for (spellIndex in spells.indices) {
+    val spellStrength = spells[spellIndex].toLong()
+    val minPotionNeeded = if (spellStrength == 0L) {
+      Long.MAX_VALUE
+    } else {
+      (success + spellStrength - 1L) / spellStrength
+    }
+
+    if (minPotionNeeded > Int.MAX_VALUE.toLong()) {
+      result[spellIndex] = 0
+      continue
+    }
+
+    val firstIndex = lowerBoundForLongTarget(potions, minPotionNeeded)
+    result[spellIndex] = totalPotions - firstIndex
+  }
+
+  return result
+}
+
+private fun lowerBoundForLongTarget(sortedPotions: IntArray, target: Long): Int {
+  var left = 0
+  var right = sortedPotions.size
+  while (left < right) {
+    val mid = left + (right - left) / 2
+    if (sortedPotions[mid].toLong() < target) {
+      left = mid + 1
+    } else {
+      right = mid
+    }
+  }
+  return left
+}


### PR DESCRIPTION
## Summary
- add a top-level implementation for counting successful spell and potion pairs
- reuse a lower-bound search helper to find the first valid potion index efficiently

## Testing
- ./gradlew test --console=plain
- ./gradlew detekt --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e65af6ca7c8321bdc1a5c989e034b9