### PR TITLE
feat: add remove anagrams solution

### DIFF
--- a/src/main/kotlin/problems/RemoveAnagrams.kt
+++ b/src/main/kotlin/problems/RemoveAnagrams.kt
@@ -1,0 +1,28 @@
+package problems
+
+fun removeAnagrams(words: Array<String>): List<String> {
+  val remainingWords = mutableListOf<String>()
+  var previousSignature: String? = null
+
+  for (currentWord in words) {
+    val currentSignature = signatureKey(currentWord)
+    if (currentSignature != previousSignature) {
+      remainingWords.add(currentWord)
+      previousSignature = currentSignature
+    }
+  }
+  return remainingWords
+}
+
+private fun signatureKey(text: String): String {
+  val letterCounts = IntArray(26)
+  for (character in text) {
+    val index = character - 'a'
+    letterCounts[index] = letterCounts[index] + 1
+  }
+  val builder = StringBuilder(26 * 2)
+  for (count in letterCounts) {
+    builder.append(count).append('#')
+  }
+  return builder.toString()
+}


### PR DESCRIPTION
## Summary
- add a top-level removeAnagrams helper that skips adjacent words sharing the same letter signature

## Testing
- ./gradlew test --console=plain
- ./gradlew detekt --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ecdbfa2b5483219514832a1753f63e