### PR TITLE
feat(push): add maxPartitionsAfterOperations solution

### DIFF
--- a/src/main/kotlin/problems/push/Push.kt
+++ b/src/main/kotlin/problems/push/Push.kt
@@ -1,27 +1,62 @@
 package problems.push
 
-class Solution {
-  fun maxArea(height: IntArray): Int {
-    var leftIndex = 0
-    var rightIndex = height.lastIndex
-    var bestArea = 0
+fun maxPartitionsAfterOperations(s: String, k: Int): Int {
+  val n = s.length
+  val left = Array(n) { IntArray(3) }
+  val right = Array(n) { IntArray(3) }
 
-    while (leftIndex < rightIndex) {
-      val width = rightIndex - leftIndex
-      val limitingHeight = if (height[leftIndex] < height[rightIndex]) {
-        height[leftIndex]
+  var segments = 0
+  var mask = 0
+  var distinctCount = 0
+  for (index in 0 until n - 1) {
+    val bit = 1 shl (s[index] - 'a')
+    if ((mask and bit) == 0) {
+      distinctCount += 1
+      if (distinctCount <= k) {
+        mask = mask or bit
       } else {
-        height[rightIndex]
-      }
-      val area = limitingHeight * width
-      if (area > bestArea) bestArea = area
-
-      if (height[leftIndex] <= height[rightIndex]) {
-        leftIndex += 1
-      } else {
-        rightIndex -= 1
+        segments += 1
+        mask = bit
+        distinctCount = 1
       }
     }
-    return bestArea
+    left[index + 1][0] = segments
+    left[index + 1][1] = mask
+    left[index + 1][2] = distinctCount
   }
+
+  segments = 0
+  mask = 0
+  distinctCount = 0
+  for (index in n - 1 downTo 1) {
+    val bit = 1 shl (s[index] - 'a')
+    if ((mask and bit) == 0) {
+      distinctCount += 1
+      if (distinctCount <= k) {
+        mask = mask or bit
+      } else {
+        segments += 1
+        mask = bit
+        distinctCount = 1
+      }
+    }
+    right[index - 1][0] = segments
+    right[index - 1][1] = mask
+    right[index - 1][2] = distinctCount
+  }
+
+  var best = 0
+  for (index in 0 until n) {
+    var current = left[index][0] + right[index][0] + 2
+    val mergedMask = left[index][1] or right[index][1]
+    val mergedDistinct = Integer.bitCount(mergedMask)
+
+    if (left[index][2] == k && right[index][2] == k && mergedDistinct < 26) {
+      current += 1
+    } else if (minOf(mergedDistinct + 1, 26) <= k) {
+      current -= 1
+    }
+    best = maxOf(best, current)
+  }
+  return best
 }


### PR DESCRIPTION
## Summary
- implement a top-level `maxPartitionsAfterOperations` solution in the push package
- track prefix and suffix segment counts and masks to choose the best operation result

## Testing
- ./gradlew test --console=plain *(fails: unresolved references to many problem functions in the test suite)*
- ./gradlew detekt --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68f25b5fbaf48321b09b664806a15770