### PR TITLE
feat(problems): add constructTransformedArray solution

### DIFF
--- a/src/main/kotlin/problems/ConstructTransformedArray.kt
+++ b/src/main/kotlin/problems/ConstructTransformedArray.kt
@@ -1,0 +1,20 @@
+fun constructTransformedArray(nums: IntArray): IntArray {
+  val arrayLength = nums.size
+  val result = IntArray(arrayLength)
+
+  for (currentIndex in nums.indices) {
+    val stepsToMove = nums[currentIndex]
+
+    if (stepsToMove == 0) {
+      result[currentIndex] = 0
+    } else {
+      val rawLandingIndex = currentIndex + stepsToMove
+      val normalizedLandingIndex =
+        ((rawLandingIndex % arrayLength) + arrayLength) % arrayLength
+
+      result[currentIndex] = nums[normalizedLandingIndex]
+    }
+  }
+
+  return result
+}

--- a/src/test/kotlin/problems/ConstructTransformedArrayTest.kt
+++ b/src/test/kotlin/problems/ConstructTransformedArrayTest.kt
@@ -1,0 +1,18 @@
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+
+class ConstructTransformedArrayTest {
+  @Test
+  fun testConstructTransformedArray() {
+    val testCases = listOf(
+      Pair(intArrayOf(3, -2, 1, 1), intArrayOf(1, 1, -2, 3)),
+      Pair(intArrayOf(0, 0, 0), intArrayOf(0, 0, 0)),
+      Pair(intArrayOf(-1, 2, -3, 4), intArrayOf(4, 4, 4, 4))
+    )
+
+    for ((nums, expected) in testCases) {
+      val result = constructTransformedArray(nums)
+      assertContentEquals(expected, result)
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a small utility problem solution that replaces each element with the element at the index reached by moving its value steps (with wrapping), handling both positive and negative steps.

### Description
- Add a top-level function `constructTransformedArray(nums: IntArray): IntArray` in the `problems` package that uses normalized modular arithmetic to compute landing indices for positive and negative jumps.
- Add unit tests `ConstructTransformedArrayTest` in `src/test/kotlin/problems` covering mixed positive/negative movement, an all-zero input, and wraparound behavior.

### Testing
- Ran `./gradlew test` which could not complete successfully due to unrelated repository Kotlin compilation errors (`Redeclaration: Solution`) in other files.
- Ran `./gradlew detekt` which reported existing Detekt violations in the repository, so lint checks for this change could not be fully validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69841af78498832188015fb4b15de738)