### PR TITLE
feat(leetcode): add Rotated Digits (LeetCode 788) solution

### DIFF
--- a/src/main/kotlin/problems/RotatedDigits.kt
+++ b/src/main/kotlin/problems/RotatedDigits.kt
@@ -1,0 +1,40 @@
+package problems
+
+fun rotatedDigits(n: Int): Int {
+  var goodCount = 0
+
+  for (number in 1..n) {
+    if (isGoodNumber(number)) {
+      goodCount += 1
+    }
+  }
+
+  return goodCount
+}
+
+private fun isGoodNumber(number: Int): Boolean {
+  var current = number
+  var hasDifferentDigit = false
+
+  while (current > 0) {
+    val digit = current % 10
+
+    when (digit) {
+      0, 1, 8 -> {
+        // remains the same
+      }
+
+      2, 5, 6, 9 -> {
+        hasDifferentDigit = true
+      }
+
+      else -> {
+        return false
+      }
+    }
+
+    current /= 10
+  }
+
+  return hasDifferentDigit
+}

--- a/src/test/kotlin/problems/RotatedDigitsTest.kt
+++ b/src/test/kotlin/problems/RotatedDigitsTest.kt
@@ -1,0 +1,19 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class RotatedDigitsTest {
+  @Test
+  fun testRotatedDigitsExamples() {
+    assertEquals(4, rotatedDigits(10))
+    assertEquals(0, rotatedDigits(1))
+    assertEquals(1, rotatedDigits(2))
+  }
+
+  @Test
+  fun testRotatedDigitsAdditionalCases() {
+    assertEquals(9, rotatedDigits(20))
+    assertEquals(15, rotatedDigits(30))
+  }
+}


### PR DESCRIPTION
### Motivation

- Add a concise top-level solution for LeetCode 788 that validates rotated digits by per-digit rules and counts "good" numbers up to `n`.
- Provide unit tests to document expected behavior and catch regressions for example and small additional ranges.

### Description

- Add a new top-level function `rotatedDigits(n: Int)` in the `problems` package that iterates `1..n` and counts valid numbers.
- Implement a helper `isGoodNumber(number: Int)` that rejects invalid digits and requires at least one transforming digit (`2,5,6,9`) while accepting stable digits (`0,1,8`).
- Add unit tests in `src/test/kotlin/problems/RotatedDigitsTest.kt` that cover example cases and extra ranges (`n = 10, 1, 2, 20, 30`).

### Testing

- Ran `./gradlew test`, which failed in this environment due to a missing Java 25 toolchain and thus tests were not executed. 
- Ran `./gradlew detekt`, which also failed due to the same missing Java 25 toolchain and static analysis was not executed. }

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60855f8d483219a746ad73ed950ca)