### PR TITLE
feat(leetcode): rotate image via transpose-and-reverse in-place

### DIFF
--- a/src/main/kotlin/problems/RotateImage.kt
+++ b/src/main/kotlin/problems/RotateImage.kt
@@ -1,26 +1,28 @@
 package problems
 
-fun rotate(matrix: Array<IntArray>): Unit {
-  // Get the size of the matrix (n x n)
-  val len = matrix.size
+fun rotate(matrix: Array<IntArray>) {
+  val size = matrix.size
 
-  // Iterate through each layer of the matrix
-  for (row in 0 until len / 2) { // Loop through the rows up to the middle
-    for (col in 0 until (len + 1) / 2) { // Loop through the columns up to the middle
-      // Store the value of the current element (top-left)
-      val tmp = matrix[row][col]
+  // Step 1: transpose matrix across main diagonal
+  for (row in 0 until size) {
+    for (col in row until size) {
+      val temp = matrix[row][col]
+      matrix[row][col] = matrix[col][row]
+      matrix[col][row] = temp
+    }
+  }
 
-      // Move the bottom-left element to the top-left position
-      matrix[row][col] = matrix[len - col - 1][row]
+  // Step 2: reverse each row
+  for (row in 0 until size) {
+    var leftColumn = 0
+    var rightColumn = size - 1
 
-      // Move the bottom-right element to the bottom-left position
-      matrix[len - col - 1][row] = matrix[len - row - 1][len - col - 1]
-
-      // Move the top-right element to the bottom-right position
-      matrix[len - row - 1][len - col - 1] = matrix[col][len - row - 1]
-
-      // Assign the saved value (original top-left) to the top-right position
-      matrix[col][len - row - 1] = tmp
+    while (leftColumn < rightColumn) {
+      val temp = matrix[row][leftColumn]
+      matrix[row][leftColumn] = matrix[row][rightColumn]
+      matrix[row][rightColumn] = temp
+      leftColumn += 1
+      rightColumn -= 1
     }
   }
 }
@@ -64,7 +66,6 @@ private fun reverseRows(matrix: Array<IntArray>) {
     row.reverse()
   }
 }
-
 
 fun matrixEquals(a: Array<IntArray>, b: Array<IntArray>): Boolean {
   if (a.size != b.size) return false


### PR DESCRIPTION
### Motivation
- Replace the layer-wise 4-way swap with a clearer in-place `transpose` + `reverse rows` approach for a 90° clockwise rotation while keeping the solution as a top-level function in the `problems` package.
- Keep existing alternative implementations and helpers to preserve reference implementations and tests.

### Description
- Rewrote `rotate(matrix: Array<IntArray>)` to first transpose the matrix across the main diagonal and then reverse each row to achieve the in-place rotation; variable `len` was renamed to `size` and step comments were added.
- Kept `rotateBruteForce`, `rotateFunctional`, `transpose`, `reverseRows`, and `matrixEquals` in place and unchanged in API or package placement.
- Maintained top-level function placement and problem package constraints required by project conventions.

### Testing
- Ran `./gradlew test` which could not complete in this environment due to a missing Java toolchain (requested languageVersion=25) and therefore failed.
- Ran `./gradlew detekt` which also failed for the same missing Java toolchain reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b0f7f62883218af95edc6e784b04)