### PR TITLE
feat(problems): add rotate list solution and tests

### DIFF
--- a/src/main/kotlin/problems/RotateList.kt
+++ b/src/main/kotlin/problems/RotateList.kt
@@ -1,61 +1,33 @@
 package problems
 
 fun rotateRight(head: ListNode?, k: Int): ListNode? {
-  // Handle edge cases
-  if (head?.next == null || k == 0) return head
+  if (head == null || head.next == null || k == 0) {
+    return head
+  }
 
-  // Step 1: Calculate length and find the last node
   var length = 1
   var tail = head
   while (tail?.next != null) {
-    length++
     tail = tail.next
+    length += 1
   }
 
-  // Step 2: Calculate effective rotation amount
-  val effectiveK = k % length
-  if (effectiveK == 0) return head
+  tail?.next = head
 
-  // Step 3: Find the new tail position (length - effectiveK - 1)
+  val effectiveRotation = k % length
+  if (effectiveRotation == 0) {
+    tail?.next = null
+    return head
+  }
+
+  val stepsToNewTail = length - effectiveRotation
   var newTail = head
-  repeat(length - effectiveK - 1) {
+  for (step in 1 until stepsToNewTail) {
     newTail = newTail?.next
   }
 
-  // Step 4: Perform rotation
   val newHead = newTail?.next
   newTail?.next = null
-  tail?.next = head
 
   return newHead
 }
-
-// Extension function to create linked list from list for testing
-private fun List<Int>.toLinkedList(): ListNode? {
-  if (isEmpty()) return null
-
-  val head = ListNode(first())
-  var current = head
-
-  for (value in drop(1)) {
-    current.next = ListNode(value)
-    current = current.next!!
-  }
-
-  return head
-}
-
-// Extension function to convert linked list to list for testing
-fun ListNode?.toList(): List<Int> {
-  val result = mutableListOf<Int>()
-  var current = this
-
-  while (current != null) {
-    result.add(current.`val`)
-    current = current.next
-  }
-
-  return result
-}
-
-// Test cases

--- a/src/test/kotlin/problems/RotateListTest.kt
+++ b/src/test/kotlin/problems/RotateListTest.kt
@@ -1,0 +1,67 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RotateListTest {
+
+  private fun listToNode(nums: List<Int>): ListNode? {
+    if (nums.isEmpty()) return null
+
+    val dummy = ListNode(0)
+    var current = dummy
+
+    for (num in nums) {
+      current.next = ListNode(num)
+      current = current.next!!
+    }
+
+    return dummy.next
+  }
+
+  private fun nodeToList(head: ListNode?): List<Int> {
+    val result = mutableListOf<Int>()
+    var current = head
+
+    while (current != null) {
+      result.add(current.`val`)
+      current = current.next
+    }
+
+    return result
+  }
+
+  @Test
+  fun rotatesRightByK() {
+    val input = listToNode(listOf(1, 2, 3, 4, 5))
+
+    val result = rotateRight(input, 2)
+
+    assertEquals(listOf(4, 5, 1, 2, 3), nodeToList(result))
+  }
+
+  @Test
+  fun handlesLargeKWithModulo() {
+    val input = listToNode(listOf(0, 1, 2))
+
+    val result = rotateRight(input, 4)
+
+    assertEquals(listOf(2, 0, 1), nodeToList(result))
+  }
+
+  @Test
+  fun returnsSameListWhenKIsZero() {
+    val input = listToNode(listOf(1, 2))
+
+    val result = rotateRight(input, 0)
+
+    assertEquals(listOf(1, 2), nodeToList(result))
+  }
+
+  @Test
+  fun handlesEmptyList() {
+    val result = rotateRight(null, 99)
+
+    assertEquals(emptyList(), nodeToList(result))
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a clean, production-ready implementation of the "Rotate List" problem using the cycle-based rotation approach to handle large `k` values efficiently. 
- Move any test/demo helpers out of the main source so the `main` module only contains the solution function and tests live in the `test` module. 
- Add unit tests to ensure correct behavior for common and edge cases (large `k`, zero rotation, and null input).

### Description

- Implemented a top-level function `rotateRight(head: ListNode?, k: Int): ListNode?` in `src/main/kotlin/problems/RotateList.kt` that forms a cycle, computes the effective rotation, finds the new tail, breaks the cycle, and returns the new head. 
- Removed non-production helper/demo list conversion code from the main source so the solution file only contains the problem function. 
- Added `src/test/kotlin/problems/RotateListTest.kt` with tests covering standard rotation, large-`k` modulo behavior, zero-rotation behavior, and null/empty list handling. 

### Testing

- Ran `./gradlew test` which failed in this environment due to a missing Java toolchain requirement (Gradle requested Java languageVersion 25). 
- Ran `./gradlew detekt` which also failed for the same missing Java toolchain reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f7ce20e08321b0126b761bafbc59)