### PR TITLE
feat(leetcode): add rotating the box solution

### DIFF
--- a/src/main/kotlin/problems/RotatingTheBox.kt
+++ b/src/main/kotlin/problems/RotatingTheBox.kt
@@ -1,0 +1,31 @@
+package problems
+
+fun rotateTheBox(boxGrid: Array<CharArray>): Array<CharArray> {
+  val rowCount = boxGrid.size
+  val colCount = boxGrid[0].size
+
+  for (rowIndex in 0 until rowCount) {
+    var emptyPosition = colCount - 1
+
+    for (colIndex in colCount - 1 downTo 0) {
+      when (boxGrid[rowIndex][colIndex]) {
+        '*' -> emptyPosition = colIndex - 1
+        '#' -> {
+          boxGrid[rowIndex][colIndex] = '.'
+          boxGrid[rowIndex][emptyPosition] = '#'
+          emptyPosition -= 1
+        }
+      }
+    }
+  }
+
+  val rotatedBox = Array(colCount) { CharArray(rowCount) }
+
+  for (rowIndex in 0 until rowCount) {
+    for (colIndex in 0 until colCount) {
+      rotatedBox[colIndex][rowCount - 1 - rowIndex] = boxGrid[rowIndex][colIndex]
+    }
+  }
+
+  return rotatedBox
+}

--- a/src/test/kotlin/problems/RotatingTheBoxTest.kt
+++ b/src/test/kotlin/problems/RotatingTheBoxTest.kt
@@ -1,0 +1,84 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class RotatingTheBoxTest {
+
+  @Test
+  fun testExample1() {
+    val boxGrid = arrayOf(
+      charArrayOf('#', '.', '#')
+    )
+    val expected = arrayOf(
+      charArrayOf('.'),
+      charArrayOf('#'),
+      charArrayOf('#')
+    )
+
+    assertBoxEquals(expected, rotateTheBox(boxGrid))
+  }
+
+  @Test
+  fun testExample2() {
+    val boxGrid = arrayOf(
+      charArrayOf('#', '.', '*', '.'),
+      charArrayOf('#', '#', '*', '.')
+    )
+    val expected = arrayOf(
+      charArrayOf('#', '.'),
+      charArrayOf('#', '#'),
+      charArrayOf('*', '*'),
+      charArrayOf('.', '.')
+    )
+
+    assertBoxEquals(expected, rotateTheBox(boxGrid))
+  }
+
+  @Test
+  fun testExample3() {
+    val boxGrid = arrayOf(
+      charArrayOf('#', '#', '*', '.', '*', '.'),
+      charArrayOf('#', '#', '#', '*', '.', '.'),
+      charArrayOf('#', '#', '#', '.', '#', '.')
+    )
+    val expected = arrayOf(
+      charArrayOf('.', '#', '#'),
+      charArrayOf('.', '#', '#'),
+      charArrayOf('#', '#', '*'),
+      charArrayOf('#', '*', '.'),
+      charArrayOf('#', '.', '*'),
+      charArrayOf('#', '.', '.')
+    )
+
+    assertBoxEquals(expected, rotateTheBox(boxGrid))
+  }
+
+  @Test
+  fun testObstaclesSplitRowIntoIndependentSegments() {
+    val boxGrid = arrayOf(
+      charArrayOf('#', '.', '*', '#', '.', '.', '*', '#', '.')
+    )
+    val expected = arrayOf(
+      charArrayOf('.'),
+      charArrayOf('#'),
+      charArrayOf('*'),
+      charArrayOf('.'),
+      charArrayOf('.'),
+      charArrayOf('#'),
+      charArrayOf('*'),
+      charArrayOf('.'),
+      charArrayOf('#')
+    )
+
+    assertBoxEquals(expected, rotateTheBox(boxGrid))
+  }
+
+  private fun assertBoxEquals(expected: Array<CharArray>, actual: Array<CharArray>) {
+    assertEquals(expected.size, actual.size)
+    for (rowIndex in expected.indices) {
+      assertContentEquals(expected[rowIndex], actual[rowIndex])
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a solution for LeetCode 1861 (Rotating the Box) that simulates stone gravity then rotates the box to produce the final configuration.
- Follow repository conventions by adding a top-level function in the `problems` package and tests in the test module.

### Description
- Add `rotateTheBox(boxGrid: Array<CharArray>): Array<CharArray>` in `src/main/kotlin/problems/RotatingTheBox.kt` which first applies rightward gravity per row and then rotates the matrix 90° clockwise.
- Gravity is simulated by scanning each row from right-to-left, moving `#` to the next available position and treating `*` as segment boundaries.
- Rotation builds a new `Array<CharArray>` using the mapping `rotated[col][rowCount - 1 - row] = boxGrid[row][col]` to produce the final oriented box.
- Add unit tests in `src/test/kotlin/problems/RotatingTheBoxTest.kt` covering the LeetCode examples and an obstacle-separated row scenario.

### Testing
- Ran `./gradlew test --tests problems.RotatingTheBoxTest`, which passed.
- Ran `./gradlew detekt`, which completed with no findings.
- Ran the full test suite with `./gradlew test`, which failed due to 13 unrelated existing test failures including `LastNonEmptyStringTest`, `MaxWallsDestroyedByRobotsTest`, `MaximumNestingDepthTest`, `MinimizeStringLengthTest`, `MinimumOperationsToMakeAUniValueGridTest`, `RobotCollisionsTest`, `SumOfDistancesTest`, and `WalkingRobotSimulation*` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4a51e78c8321b587934624e8af59)