### PR TITLE
feat(leetcode): add Jump Game IX solution and tests

### DIFF
--- a/src/main/kotlin/problems/JumpGameIX.kt
+++ b/src/main/kotlin/problems/JumpGameIX.kt
@@ -1,0 +1,31 @@
+package problems
+
+fun maxValue(nums: IntArray): IntArray {
+  val size = nums.size
+  val suffixMinimum = IntArray(size + 1) { Int.MAX_VALUE }
+
+  for (index in size - 1 downTo 0) {
+    suffixMinimum[index] = minOf(nums[index], suffixMinimum[index + 1])
+  }
+
+  val answer = IntArray(size)
+  var componentStart = 0
+  var currentMaximum = Int.MIN_VALUE
+
+  for (index in 0 until size) {
+    currentMaximum = maxOf(currentMaximum, nums[index])
+
+    val isComponentEnd =
+      index == size - 1 || currentMaximum <= suffixMinimum[index + 1]
+
+    if (isComponentEnd) {
+      for (fillIndex in componentStart..index) {
+        answer[fillIndex] = currentMaximum
+      }
+      componentStart = index + 1
+      currentMaximum = Int.MIN_VALUE
+    }
+  }
+
+  return answer
+}

--- a/src/test/kotlin/problems/JumpGameIXTest.kt
+++ b/src/test/kotlin/problems/JumpGameIXTest.kt
@@ -1,0 +1,34 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+
+class JumpGameIXTest {
+  @Test
+  fun splitsWhenThereIsNoCrossingInversion() {
+    val nums = intArrayOf(2, 1, 3, 5, 4)
+
+    assertContentEquals(intArrayOf(2, 2, 3, 5, 5), maxValue(nums))
+  }
+
+  @Test
+  fun connectsAcrossEveryCutWithDescendingValues() {
+    val nums = intArrayOf(5, 4, 3, 2, 1)
+
+    assertContentEquals(intArrayOf(5, 5, 5, 5, 5), maxValue(nums))
+  }
+
+  @Test
+  fun keepsNonDecreasingValuesAsSingleIndexComponents() {
+    val nums = intArrayOf(1, 1, 2, 3, 3)
+
+    assertContentEquals(intArrayOf(1, 1, 2, 3, 3), maxValue(nums))
+  }
+
+  @Test
+  fun mergesMultipleOverlappingInversionRanges() {
+    val nums = intArrayOf(3, 1, 4, 2, 5)
+
+    assertContentEquals(intArrayOf(4, 4, 4, 4, 5), maxValue(nums))
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a top-level Kotlin solution for LeetCode 3660 that computes, for each index, the maximum reachable value in its inversion-graph connected component using an O(n) scan.

### Description
- Add `maxValue(nums: IntArray): IntArray` as a top-level function in `src/main/kotlin/problems/JumpGameIX.kt` that builds a `suffixMinimum` array and partitions the array into components, filling each component with its maximum.
- Add unit tests in `src/test/kotlin/problems/JumpGameIXTest.kt` covering split components, fully descending connectivity, non-decreasing single-index components, and overlapping inversion ranges.
- Adjust the overlapping-range test expectation to match the inversion-graph connectivity behavior and commit both files under `feat(leetcode): add jump game ix solution`.

### Testing
- Ran `./gradlew test --tests problems.JumpGameIXTest`, which failed to run because the environment lacks the configured Java 25 toolchain. 
- Ran `./gradlew test`, which failed for the same Java toolchain provisioning issue. 
- Ran `./gradlew detekt`, which failed due to the same toolchain/configuration problem. 
- Verified `git diff --cached --check` passed with no index-time issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb0c81c8883219e9e763c65508b03)