### PR TITLE
feat(leetcode): add cyclically rotating grid solution

### DIFF
--- a/src/main/kotlin/problems/CyclicallyRotatingAGrid.kt
+++ b/src/main/kotlin/problems/CyclicallyRotatingAGrid.kt
@@ -1,0 +1,79 @@
+package problems
+
+fun rotateGrid(grid: Array<IntArray>, k: Int): Array<IntArray> {
+  val rowCount = grid.size
+  val columnCount = grid[0].size
+  val layerCount = minOf(rowCount, columnCount) / 2
+
+  for (layer in 0 until layerCount) {
+    val top = layer
+    val bottom = rowCount - 1 - layer
+    val left = layer
+    val right = columnCount - 1 - layer
+    val layerValues = collectLayerValues(grid, top, bottom, left, right)
+    val rotation = k % layerValues.size
+    writeLayerValues(grid, top, bottom, left, right, layerValues, rotation)
+  }
+
+  return grid
+}
+
+private fun collectLayerValues(
+  grid: Array<IntArray>,
+  top: Int,
+  bottom: Int,
+  left: Int,
+  right: Int,
+): List<Int> {
+  val layerValues = mutableListOf<Int>()
+
+  for (column in left..right) {
+    layerValues.add(grid[top][column])
+  }
+
+  for (row in top + 1 until bottom) {
+    layerValues.add(grid[row][right])
+  }
+
+  for (column in right downTo left) {
+    layerValues.add(grid[bottom][column])
+  }
+
+  for (row in bottom - 1 downTo top + 1) {
+    layerValues.add(grid[row][left])
+  }
+
+  return layerValues
+}
+
+private fun writeLayerValues(
+  grid: Array<IntArray>,
+  top: Int,
+  bottom: Int,
+  left: Int,
+  right: Int,
+  layerValues: List<Int>,
+  rotation: Int,
+) {
+  var valueIndex = 0
+
+  for (column in left..right) {
+    grid[top][column] = layerValues[(valueIndex + rotation) % layerValues.size]
+    valueIndex += 1
+  }
+
+  for (row in top + 1 until bottom) {
+    grid[row][right] = layerValues[(valueIndex + rotation) % layerValues.size]
+    valueIndex += 1
+  }
+
+  for (column in right downTo left) {
+    grid[bottom][column] = layerValues[(valueIndex + rotation) % layerValues.size]
+    valueIndex += 1
+  }
+
+  for (row in bottom - 1 downTo top + 1) {
+    grid[row][left] = layerValues[(valueIndex + rotation) % layerValues.size]
+    valueIndex += 1
+  }
+}

--- a/src/test/kotlin/problems/CyclicallyRotatingAGridTest.kt
+++ b/src/test/kotlin/problems/CyclicallyRotatingAGridTest.kt
@@ -1,0 +1,71 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CyclicallyRotatingAGridTest {
+
+  @Test
+  fun rotateGridRotatesAllLayersCounterClockwise() {
+    val grid = arrayOf(
+      intArrayOf(1, 2, 3, 4),
+      intArrayOf(5, 6, 7, 8),
+      intArrayOf(9, 10, 11, 12),
+      intArrayOf(13, 14, 15, 16),
+    )
+
+    val expected = arrayOf(
+      intArrayOf(3, 4, 8, 12),
+      intArrayOf(2, 11, 10, 16),
+      intArrayOf(1, 7, 6, 15),
+      intArrayOf(5, 9, 13, 14),
+    )
+
+    assertGridEquals(expected, rotateGrid(grid, 2))
+  }
+
+  @Test
+  fun rotateGridHandlesLargeRotationCounts() {
+    val grid = arrayOf(
+      intArrayOf(40, 10),
+      intArrayOf(30, 20),
+    )
+
+    val expected = arrayOf(
+      intArrayOf(10, 20),
+      intArrayOf(40, 30),
+    )
+
+    assertGridEquals(expected, rotateGrid(grid, 5))
+  }
+
+  @Test
+  fun rotateGridHandlesRectangularGrids() {
+    val grid = arrayOf(
+      intArrayOf(1, 2, 3, 4),
+      intArrayOf(5, 6, 7, 8),
+      intArrayOf(9, 10, 11, 12),
+      intArrayOf(13, 14, 15, 16),
+      intArrayOf(17, 18, 19, 20),
+      intArrayOf(21, 22, 23, 24),
+    )
+
+    val expected = arrayOf(
+      intArrayOf(3, 4, 8, 12),
+      intArrayOf(2, 11, 15, 16),
+      intArrayOf(1, 7, 19, 20),
+      intArrayOf(5, 6, 18, 24),
+      intArrayOf(9, 10, 14, 23),
+      intArrayOf(13, 17, 21, 22),
+    )
+
+    assertGridEquals(expected, rotateGrid(grid, 2))
+  }
+
+  private fun assertGridEquals(expected: Array<IntArray>, actual: Array<IntArray>) {
+    assertTrue(
+      expected.contentDeepEquals(actual),
+      "Expected ${expected.contentDeepToString()}, but was ${actual.contentDeepToString()}",
+    )
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a correct top-level solution for LeetCode 1914 (cyclically rotating each matrix layer counter-clockwise) and provide unit coverage for common cases.

### Description
- Add `src/main/kotlin/problems/CyclicallyRotatingAGrid.kt` implementing `rotateGrid` as a top-level function and private helpers `collectLayerValues` and `writeLayerValues` to extract and write layer values.
- Traverse each layer in the order top row → right column → bottom row → left column, normalize the rotation with `k % layerSize`, and write values back using the computed offset.
- Add `src/test/kotlin/problems/CyclicallyRotatingAGridTest.kt` with tests for a square grid example, large rotation counts, and rectangular grids.
- Adjust the rectangular-grid test expected values to match the implemented traversal/rotation semantics.

### Testing
- Ran `./gradlew test --tests problems.CyclicallyRotatingAGridTest` and the targeted test class passed after updating the rectangular-grid expectations.
- Ran `./gradlew detekt` which completed successfully with no findings.
- Ran `./gradlew test` which failed due to unrelated, pre-existing test failures elsewhere in the test suite (some unrelated tests failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff4b7a6c088321a9deb4b9593992a2)