### PR TITLE
feat(leetcode): add jump game iii solution

### DIFF
--- a/src/main/kotlin/problems/JumpGameIII.kt
+++ b/src/main/kotlin/problems/JumpGameIII.kt
@@ -1,0 +1,30 @@
+package problems
+
+fun canReach(arr: IntArray, start: Int): Boolean {
+  val visited = BooleanArray(arr.size)
+  val queue = ArrayDeque<Int>()
+  queue.addLast(start)
+  visited[start] = true
+
+  while (queue.isNotEmpty()) {
+    val currentIndex = queue.removeFirst()
+
+    if (arr[currentIndex] == 0) {
+      return true
+    }
+
+    val forwardIndex = currentIndex + arr[currentIndex]
+    if (forwardIndex in arr.indices && !visited[forwardIndex]) {
+      visited[forwardIndex] = true
+      queue.addLast(forwardIndex)
+    }
+
+    val backwardIndex = currentIndex - arr[currentIndex]
+    if (backwardIndex in arr.indices && !visited[backwardIndex]) {
+      visited[backwardIndex] = true
+      queue.addLast(backwardIndex)
+    }
+  }
+
+  return false
+}

--- a/src/test/kotlin/problems/JumpGameIIITest.kt
+++ b/src/test/kotlin/problems/JumpGameIIITest.kt
@@ -1,0 +1,17 @@
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import problems.canReach
+
+class JumpGameIIITest {
+  @Test
+  fun `can reach zero from start`() {
+    assertTrue(canReach(intArrayOf(4, 2, 3, 0, 3, 1, 2), 5))
+    assertTrue(canReach(intArrayOf(4, 2, 3, 0, 3, 1, 2), 0))
+  }
+
+  @Test
+  fun `cannot reach zero from start`() {
+    assertFalse(canReach(intArrayOf(3, 0, 2, 1, 2), 2))
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a solution for the Jump Game III problem as a top-level function in the `problems` package so the repository includes a tested implementation of this LeetCode problem.

### Description
- Added `src/main/kotlin/problems/JumpGameIII.kt` which implements `fun canReach(arr: IntArray, start: Int): Boolean` using BFS with a `visited` boolean array and an `ArrayDeque` to explore forward and backward jumps.
- Added unit tests in `src/test/kotlin/problems/JumpGameIIITest.kt` that cover reachable and unreachable start cases.

### Testing
- Ran `./gradlew test` which executed the full test suite and failed due to 13 unrelated pre-existing test failures.
- Ran `./gradlew test --tests JumpGameIIITest` which executed only the new test class and succeeded.
- Ran `./gradlew detekt` which completed successfully with no findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09df8af14c832184c616264e15859c)