### PR TITLE
feat(leetcode): add Jump Game IV solution

### DIFF
--- a/src/main/kotlin/problems/JumpGameIV.kt
+++ b/src/main/kotlin/problems/JumpGameIV.kt
@@ -1,0 +1,52 @@
+package problems
+
+fun minJumps(arr: IntArray): Int {
+  val lastIndex = arr.lastIndex
+  if (lastIndex == 0) return 0
+
+  val valueToIndices = HashMap<Int, MutableList<Int>>()
+  for (index in arr.indices) {
+    valueToIndices.getOrPut(arr[index]) { mutableListOf() }.add(index)
+  }
+
+  val visited = BooleanArray(arr.size)
+  val queue = ArrayDeque<Int>()
+  queue.addLast(0)
+  visited[0] = true
+
+  var steps = 0
+
+  while (queue.isNotEmpty()) {
+    repeat(queue.size) {
+      val currentIndex = queue.removeFirst()
+      if (currentIndex == lastIndex) return steps
+
+      val currentValue = arr[currentIndex]
+      val sameValueIndices = valueToIndices[currentValue]
+      if (sameValueIndices != null) {
+        for (nextIndex in sameValueIndices) {
+          if (!visited[nextIndex]) {
+            visited[nextIndex] = true
+            queue.addLast(nextIndex)
+          }
+        }
+        valueToIndices.remove(currentValue)
+      }
+
+      val leftIndex = currentIndex - 1
+      if (leftIndex >= 0 && !visited[leftIndex]) {
+        visited[leftIndex] = true
+        queue.addLast(leftIndex)
+      }
+
+      val rightIndex = currentIndex + 1
+      if (rightIndex <= lastIndex && !visited[rightIndex]) {
+        visited[rightIndex] = true
+        queue.addLast(rightIndex)
+      }
+    }
+    steps++
+  }
+
+  return -1
+}

--- a/src/test/kotlin/problems/JumpGameIVTest.kt
+++ b/src/test/kotlin/problems/JumpGameIVTest.kt
@@ -1,0 +1,26 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class JumpGameIVTest {
+  @Test
+  fun minJumpsReturnsMinimumJumpsForSampleWithRepeatedValues() {
+    assertEquals(3, minJumps(intArrayOf(100, -23, -23, 404, 100, 23, 23, 23, 3, 404)))
+  }
+
+  @Test
+  fun minJumpsReturnsZeroForSingleElementArray() {
+    assertEquals(0, minJumps(intArrayOf(7)))
+  }
+
+  @Test
+  fun minJumpsCanJumpDirectlyAcrossMatchingValues() {
+    assertEquals(1, minJumps(intArrayOf(7, 6, 9, 6, 9, 6, 9, 7)))
+  }
+
+  @Test
+  fun minJumpsWalksThroughArrayWhenNoShortcutExists() {
+    assertEquals(2, minJumps(intArrayOf(6, 1, 9)))
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement LeetCode 1345 (Jump Game IV) as a top-level function in the `problems` package to match repository conventions. 
- Provide a clear BFS solution that finds the minimum jumps where same-value indices are treated as fast shortcuts. 
- Add unit tests to validate common scenarios and edge cases.

### Description
- Added `minJumps(arr: IntArray): Int` as a top-level function that performs BFS using an `ArrayDeque`, a `visited` BooleanArray, and a `valueToIndices` map to group equal values and clear groups after processing. 
- The BFS checks neighbors `i-1`, `i+1`, and all indices with the same value, and returns steps when the last index is reached. 
- Added unit tests in `JumpGameIVTest.kt` covering the provided sample, a single-element array, a same-value shortcut case, and a linear-walk case. 
- New files: `src/main/kotlin/problems/JumpGameIV.kt` and `src/test/kotlin/problems/JumpGameIVTest.kt`.

### Testing
- Ran `./gradlew detekt` (with `JAVA_HOME=/root/.local/share/mise/installs/java/25.0.2` when needed), and analysis completed successfully with no Detekt findings. 
- Ran the Jump Game IV tests with `./gradlew test --tests problems.JumpGameIVTest` (using `JAVA_HOME=/root/.local/share/mise/installs/java/25.0.2`) and the test class passed. 
- Running the full test suite with `./gradlew test` in this environment resulted in 13 pre-existing unrelated failing tests, so the full suite did not pass here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b16dcb71083218c019a7ae578f993)