### PR TITLE
feat(problems): add FindThePrefixCommonArray solution and tests

### DIFF
--- a/src/main/kotlin/problems/FindThePrefixCommonArrayOfTwoArrays.kt
+++ b/src/main/kotlin/problems/FindThePrefixCommonArrayOfTwoArrays.kt
@@ -1,0 +1,36 @@
+package problems
+
+/**
+ * LeetCode 2657. Find the Prefix Common Array of Two Arrays
+ * https://leetcode.com/problems/find-the-prefix-common-array-of-two-arrays/
+ */
+fun findThePrefixCommonArray(a: IntArray, b: IntArray): IntArray {
+  val arrayLength = a.size
+
+  val seenInA = BooleanArray(arrayLength + 1)
+  val seenInB = BooleanArray(arrayLength + 1)
+
+  val prefixCommonArray = IntArray(arrayLength)
+
+  var commonCount = 0
+
+  for (index in 0 until arrayLength) {
+    val valueFromA = a[index]
+    val valueFromB = b[index]
+
+    seenInA[valueFromA] = true
+    seenInB[valueFromB] = true
+
+    if (seenInA[valueFromB]) {
+      commonCount += 1
+    }
+
+    if (valueFromA != valueFromB && seenInB[valueFromA]) {
+      commonCount += 1
+    }
+
+    prefixCommonArray[index] = commonCount
+  }
+
+  return prefixCommonArray
+}

--- a/src/test/kotlin/problems/FindThePrefixCommonArrayOfTwoArraysTest.kt
+++ b/src/test/kotlin/problems/FindThePrefixCommonArrayOfTwoArraysTest.kt
@@ -1,0 +1,22 @@
+package problems
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Test
+
+class FindThePrefixCommonArrayOfTwoArraysTest {
+  @Test
+  fun testExample1() {
+    val a = intArrayOf(1,3,2,4)
+    val b = intArrayOf(3,1,2,4)
+
+    assertArrayEquals(intArrayOf(0,2,3,4), findThePrefixCommonArray(a, b))
+  }
+
+  @Test
+  fun testExample2() {
+    val a = intArrayOf(2,3,1)
+    val b = intArrayOf(3,1,2)
+
+    assertArrayEquals(intArrayOf(0,1,3), findThePrefixCommonArray(a, b))
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement LeetCode 2657 as a top-level function in the `problems` package to compute prefix-common counts between two arrays.
- Provide unit tests for the official examples so the solution can be validated by CI locally.

### Description
- Add `src/main/kotlin/problems/FindThePrefixCommonArrayOfTwoArrays.kt` defining `findThePrefixCommonArray(a: IntArray, b: IntArray): IntArray` that tracks seen elements and accumulates prefix common counts.
- Add `src/test/kotlin/problems/FindThePrefixCommonArrayOfTwoArraysTest.kt` with two tests using `assertArrayEquals` for the given examples.
- Keep the solution as a top-level function inside the `problems` package to follow repository conventions.

### Testing
- Ran `./gradlew test` and `./gradlew detekt` in the environment.
- The build failed because the environment lacks the required Java toolchain (`languageVersion=25`), so tests and Detekt could not complete.
- No automated tests succeeded in this environment due to the toolchain error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd3306e60832197413990c711d93a)