### PR TITLE
feat(leetcode): add longest common prefix (LeetCode 3043) solution

### DIFF
--- a/src/main/kotlin/problems/FindTheLengthOfTheLongestCommonPrefix.kt
+++ b/src/main/kotlin/problems/FindTheLengthOfTheLongestCommonPrefix.kt
@@ -1,0 +1,31 @@
+package problems
+
+fun longestCommonPrefix(arr1: IntArray, arr2: IntArray): Int {
+  val prefixes = HashSet<Int>()
+
+  for (number in arr1) {
+    var currentNumber = number
+
+    while (currentNumber > 0) {
+      prefixes.add(currentNumber)
+      currentNumber /= 10
+    }
+  }
+
+  var longestLength = 0
+
+  for (number in arr2) {
+    var currentNumber = number
+
+    while (currentNumber > 0) {
+      if (prefixes.contains(currentNumber)) {
+        longestLength = maxOf(longestLength, currentNumber.toString().length)
+        break
+      }
+
+      currentNumber /= 10
+    }
+  }
+
+  return longestLength
+}

--- a/src/test/kotlin/problems/FindTheLengthOfTheLongestCommonPrefixTest.kt
+++ b/src/test/kotlin/problems/FindTheLengthOfTheLongestCommonPrefixTest.kt
@@ -1,0 +1,24 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class FindTheLengthOfTheLongestCommonPrefixTest {
+  @Test
+  fun `returns three for sample style case`() {
+    val result = longestCommonPrefix(intArrayOf(1, 10, 100), intArrayOf(1000))
+    assertEquals(3, result)
+  }
+
+  @Test
+  fun `returns zero when there is no shared prefix`() {
+    val result = longestCommonPrefix(intArrayOf(123, 456), intArrayOf(789, 890))
+    assertEquals(0, result)
+  }
+
+  @Test
+  fun `finds best match across multiple values`() {
+    val result = longestCommonPrefix(intArrayOf(12, 9876, 42), intArrayOf(981, 12999, 777))
+    assertEquals(2, result)
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement a solution for the problem of finding the maximum prefix length shared by one number from `arr1` and one number from `arr2`, using an efficient approach that leverages numeric prefixes.

### Description
- Add a top-level function `longestCommonPrefix(arr1: IntArray, arr2: IntArray): Int` in the `problems` package that generates all prefixes of numbers in `arr1` by dividing by 10 and stores them in a `HashSet<Int>`.
- For each number in `arr2` the function trims digits from the right and checks membership in the prefix set, tracking the longest matching prefix length found, with overall complexity proportional to the number of digits processed.
- Add unit tests in `src/test/kotlin/problems/FindTheLengthOfTheLongestCommonPrefixTest.kt` covering a sample match, a no-match case, and selecting the longest match among multiple candidates.

### Testing
- Executed `./gradlew test`, which failed in this environment due to a missing Java toolchain matching languageVersion 25, so the tests could not be run here.
- Executed `./gradlew detekt`, which also failed due to the same Java toolchain availability issue, so lint checks could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0ffc5f8c8321bdc6cce1e3532b1e)