### PR TITLE
feat(problems): add Jump Game V DFS + memoization solution

### DIFF
--- a/src/main/kotlin/problems/JumpGameV.kt
+++ b/src/main/kotlin/problems/JumpGameV.kt
@@ -1,0 +1,43 @@
+package problems
+
+fun maxJumps(arr: IntArray, d: Int): Int {
+  val n = arr.size
+  val memo = IntArray(n)
+
+  fun dfs(currentIndex: Int): Int {
+    if (memo[currentIndex] != 0) {
+      return memo[currentIndex]
+    }
+
+    var best = 1
+    val currentValue = arr[currentIndex]
+
+    var nextIndex = currentIndex - 1
+    while (nextIndex >= 0 && currentIndex - nextIndex <= d) {
+      if (arr[nextIndex] >= currentValue) {
+        break
+      }
+      best = maxOf(best, 1 + dfs(nextIndex))
+      nextIndex--
+    }
+
+    nextIndex = currentIndex + 1
+    while (nextIndex < n && nextIndex - currentIndex <= d) {
+      if (arr[nextIndex] >= currentValue) {
+        break
+      }
+      best = maxOf(best, 1 + dfs(nextIndex))
+      nextIndex++
+    }
+
+    memo[currentIndex] = best
+    return best
+  }
+
+  var answer = 0
+  for (currentIndex in 0 until n) {
+    answer = maxOf(answer, dfs(currentIndex))
+  }
+
+  return answer
+}

--- a/src/test/kotlin/problems/JumpGameVTest.kt
+++ b/src/test/kotlin/problems/JumpGameVTest.kt
@@ -1,0 +1,26 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class JumpGameVTest {
+  @Test
+  fun testExample1() {
+    assertEquals(4, maxJumps(intArrayOf(6, 4, 14, 6, 8, 13, 9, 7, 10, 6, 12), 2))
+  }
+
+  @Test
+  fun testExample2() {
+    assertEquals(1, maxJumps(intArrayOf(3, 3, 3, 3, 3), 3))
+  }
+
+  @Test
+  fun testExample3() {
+    assertEquals(7, maxJumps(intArrayOf(7, 6, 5, 4, 3, 2, 1), 1))
+  }
+
+  @Test
+  fun testBlockedByHigherValue() {
+    assertEquals(2, maxJumps(intArrayOf(7, 1, 7, 1, 7, 1), 2))
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a top-level solution for LeetCode 1340 (Jump Game V) implementing the recommended DFS + memoization approach that scans left/right up to distance `d` and respects blocking heights.

### Description
- Add `src/main/kotlin/problems/JumpGameV.kt` containing a top-level function `maxJumps(arr: IntArray, d: Int): Int` that computes the maximum visits per index using DFS with an `IntArray` memoization cache. 
- Implement directional scanning from each index up to distance `d` that stops when encountering a value `>= arr[currentIndex]`, and aggregate the best reachable path length. 
- Add unit tests in `src/test/kotlin/problems/JumpGameVTest.kt` covering canonical examples, a strictly decreasing sequence, and a case blocked by higher/equal values.

### Testing
- Ran `./gradlew test`, which could not complete in this environment due to a missing Java toolchain requirement (Java languageVersion 25) so tests did not execute successfully. 
- Ran `./gradlew detekt`, which also failed for the same Java toolchain configuration issue and produced no detekt report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12a04c8e648321abf7f498b9e709a3)