### PR TITLE
feat(leetcode): add Jump Game VII BFS solution

### DIFF
--- a/src/main/kotlin/problems/JumpGameVII.kt
+++ b/src/main/kotlin/problems/JumpGameVII.kt
@@ -1,0 +1,30 @@
+fun canReachJumpGameVII(s: String, minJump: Int, maxJump: Int): Boolean {
+  if (s.last() != '0') return false
+
+  val stringLength = s.length
+  val queue = ArrayDeque<Int>()
+  queue.addLast(0)
+
+  var farthestProcessedIndex = 0
+
+  while (queue.isNotEmpty()) {
+    val currentIndex = queue.removeFirst()
+
+    if (currentIndex == stringLength - 1) {
+      return true
+    }
+
+    val startIndex = maxOf(currentIndex + minJump, farthestProcessedIndex + 1)
+    val endIndex = minOf(currentIndex + maxJump, stringLength - 1)
+
+    for (nextIndex in startIndex..endIndex) {
+      if (s[nextIndex] == '0') {
+        queue.addLast(nextIndex)
+      }
+    }
+
+    farthestProcessedIndex = maxOf(farthestProcessedIndex, endIndex)
+  }
+
+  return false
+}

--- a/src/test/kotlin/problems/JumpGameVIITest.kt
+++ b/src/test/kotlin/problems/JumpGameVIITest.kt
@@ -1,0 +1,25 @@
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class JumpGameVIITest {
+  @Test
+  fun exampleOne() {
+    assertTrue(canReachJumpGameVII("011010", 2, 3))
+  }
+
+  @Test
+  fun exampleTwo() {
+    assertFalse(canReachJumpGameVII("01101110", 2, 3))
+  }
+
+  @Test
+  fun singleCharacterReachable() {
+    assertTrue(canReachJumpGameVII("0", 1, 1))
+  }
+
+  @Test
+  fun blockedLastCharacter() {
+    assertFalse(canReachJumpGameVII("0101", 1, 2))
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide an efficient Kotlin solution for LeetCode 1871 (Jump Game VII) that avoids rescanning overlapping ranges and runs in linear time.
- Keep solutions as top-level functions in the `problems` source set per repository rules.
- Add unit tests to validate typical examples and edge cases for this problem.

### Description
- Add `canReachJumpGameVII(s: String, minJump: Int, maxJump: Int): Boolean` as a top-level function implementing a BFS that uses a `farthestProcessedIndex` to ensure each index is checked at most once and to maintain `O(n)` time complexity. 
- The solution short-circuits when the last character is not `'0'` and only enqueues indices whose character is `'0'`.
- Add `JumpGameVIITest.kt` with unit tests covering the provided examples, a single-character reachable case, and a blocked-last-character case.
- Files are placed under the `problems` source directory and tests are in the `test` module, complying with repository organization rules.

### Testing
- Ran `./gradlew test`, but the task failed in this environment due to a missing Java 25 toolchain and could not execute the unit tests.
- Ran `./gradlew detekt`, but it failed for the same Java toolchain resolution issue and therefore Detekt checks could not be completed.
- Tests and linting should pass in an environment with the required Java toolchain configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14048bc1248321bb02c7500c611df7)