### PR TITLE
feat(problems): add count the number of special characters i solution

### DIFF
--- a/src/main/kotlin/problems/CountTheNumberOfSpecialCharactersI.kt
+++ b/src/main/kotlin/problems/CountTheNumberOfSpecialCharactersI.kt
@@ -1,0 +1,26 @@
+package problems
+
+fun numberOfSpecialChars(word: String): Int {
+  val lowercaseLetters = mutableSetOf<Char>()
+  val uppercaseLetters = mutableSetOf<Char>()
+
+  for (character in word) {
+    if (character.isLowerCase()) {
+      lowercaseLetters.add(character)
+    } else {
+      uppercaseLetters.add(character)
+    }
+  }
+
+  var specialCharacterCount = 0
+
+  for (character in 'a'..'z') {
+    val uppercaseCharacter = character.uppercaseChar()
+
+    if (character in lowercaseLetters && uppercaseCharacter in uppercaseLetters) {
+      specialCharacterCount++
+    }
+  }
+
+  return specialCharacterCount
+}

--- a/src/test/kotlin/problems/CountTheNumberOfSpecialCharactersITest.kt
+++ b/src/test/kotlin/problems/CountTheNumberOfSpecialCharactersITest.kt
@@ -1,0 +1,14 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class CountTheNumberOfSpecialCharactersITest {
+  @Test
+  fun testNumberOfSpecialChars() {
+    assertEquals(3, numberOfSpecialChars("aaAbcBC"))
+    assertEquals(0, numberOfSpecialChars("abc"))
+    assertEquals(1, numberOfSpecialChars("abBC"))
+    assertEquals(26, numberOfSpecialChars("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+  }
+}


### PR DESCRIPTION
### Motivation

- Add a top-level Kotlin solution `numberOfSpecialChars` for LeetCode 3120 to provide a concise implementation that counts letters present in both lowercase and uppercase forms.

### Description

- Add `src/main/kotlin/problems/CountTheNumberOfSpecialCharactersI.kt` implementing `numberOfSpecialChars(word: String): Int` using lowercase and uppercase `Set<Char>` and iterating `'a'..'z'`, and add `src/test/kotlin/problems/CountTheNumberOfSpecialCharactersITest.kt` with unit tests covering mixed-case matches, no matches, partial overlap, and full-alphabet matches.

### Testing

- Attempted to run `./gradlew test` and `./gradlew detekt`, but both failed in this environment due to a missing Java toolchain requirement (`languageVersion=25`), so automated checks could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a4a20d4c8321b470e860a79f329a)