### PR TITLE
feat(leetcode): add minElement (digit-sum) solution

### DIFF
--- a/src/main/kotlin/problems/MinimumElementAfterReplacementWithDigitSum.kt
+++ b/src/main/kotlin/problems/MinimumElementAfterReplacementWithDigitSum.kt
@@ -1,0 +1,22 @@
+package problems
+
+fun minElement(nums: IntArray): Int {
+  var minimumDigitSum = Int.MAX_VALUE
+
+  for (number in nums) {
+    var currentNumber = number
+    var digitSum = 0
+
+    while (currentNumber > 0) {
+      digitSum += currentNumber % 10
+      currentNumber /= 10
+    }
+
+    if (digitSum < minimumDigitSum) {
+      minimumDigitSum = digitSum
+    }
+  }
+
+  return minimumDigitSum
+}
+

--- a/src/test/kotlin/problems/MinimumElementAfterReplacementWithDigitSumTest.kt
+++ b/src/test/kotlin/problems/MinimumElementAfterReplacementWithDigitSumTest.kt
@@ -1,0 +1,19 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MinimumElementAfterReplacementWithDigitSumTest {
+
+  @Test
+  fun testExamples() {
+    assertEquals(1, minElement(intArrayOf(10, 12, 13, 14)))
+    assertEquals(1, minElement(intArrayOf(1, 2, 3, 4)))
+    assertEquals(10, minElement(intArrayOf(999, 19, 199)))
+  }
+
+  @Test
+  fun testSingleElement() {
+    assertEquals(6, minElement(intArrayOf(123)))
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement the LeetCode 3300 solution that replaces each number with its digit sum and returns the smallest result.

### Description
- Add a top-level function `minElement(nums: IntArray)` in the `problems` package that computes each number's digit sum using `% 10` and `/= 10` and returns the minimum digit sum.
- Add `MinimumElementAfterReplacementWithDigitSumTest` in the `test` module with example cases and a single-element case to validate correctness.

### Testing
- Ran `git diff --check`, which reported no issues.
- Attempted `./gradlew test`, but it failed because the Gradle build requires a Java 25 toolchain which is not available in the environment (installed Java is 17), so tests could not be executed.
- Attempted `./gradlew detekt`, which also failed for the same Java toolchain reason.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19aecb8c3c8321804a348e6f188a7c)