### PR TITLE
feat(leetcode): add block placement queries solution

### DIFF
--- a/src/main/kotlin/problems/BlockPlacementQueries.kt
+++ b/src/main/kotlin/problems/BlockPlacementQueries.kt
@@ -1,0 +1,92 @@
+package problems
+
+import java.util.TreeSet
+import kotlin.math.max
+
+fun getResults(queries: Array<IntArray>): List<Boolean> {
+  var maxCoordinate = 0
+  for (query in queries) {
+    maxCoordinate = max(maxCoordinate, query[1])
+  }
+
+  val obstaclePositions = TreeSet<Int>()
+  obstaclePositions.add(0)
+
+  val segmentTree = BlockPlacementSegmentTree(maxCoordinate)
+  val answers = ArrayList<Boolean>()
+
+  for (query in queries) {
+    if (query[0] == 1) {
+      val obstaclePosition = query[1]
+      val previousObstacle = obstaclePositions.lower(obstaclePosition) ?: 0
+      val nextObstacle = obstaclePositions.higher(obstaclePosition)
+
+      obstaclePositions.add(obstaclePosition)
+      segmentTree.updatePoint(obstaclePosition, obstaclePosition - previousObstacle)
+
+      if (nextObstacle != null) {
+        segmentTree.updatePoint(nextObstacle, nextObstacle - obstaclePosition)
+      }
+    } else {
+      val rightBoundary = query[1]
+      val blockSize = query[2]
+      val previousObstacle = obstaclePositions.floor(rightBoundary) ?: 0
+      val tailGap = rightBoundary - previousObstacle
+      val bestGapEndingAtObstacle = segmentTree.queryPrefixMaximum(rightBoundary)
+
+      answers.add(max(bestGapEndingAtObstacle, tailGap) >= blockSize)
+    }
+  }
+
+  return answers
+}
+
+private class BlockPlacementSegmentTree(maxCoordinate: Int) {
+  private val size: Int
+  private val tree: IntArray
+
+  init {
+    var treeSize = 1
+    while (treeSize <= maxCoordinate + 2) {
+      treeSize *= 2
+    }
+    size = treeSize
+    tree = IntArray(size * 2)
+  }
+
+  fun updatePoint(position: Int, value: Int) {
+    var index = position + size
+    tree[index] = value
+    index /= 2
+
+    while (index >= 1) {
+      tree[index] = max(tree[index * 2], tree[index * 2 + 1])
+      index /= 2
+    }
+  }
+
+  fun queryPrefixMaximum(rightBoundary: Int): Int {
+    if (rightBoundary <= 0) {
+      return 0
+    }
+
+    var leftIndex = size + 1
+    var rightIndex = size + rightBoundary
+    var bestValue = 0
+
+    while (leftIndex <= rightIndex) {
+      if ((leftIndex and 1) == 1) {
+        bestValue = max(bestValue, tree[leftIndex])
+        leftIndex += 1
+      }
+      if ((rightIndex and 1) == 0) {
+        bestValue = max(bestValue, tree[rightIndex])
+        rightIndex -= 1
+      }
+      leftIndex /= 2
+      rightIndex /= 2
+    }
+
+    return bestValue
+  }
+}

--- a/src/test/kotlin/problems/BlockPlacementQueriesTest.kt
+++ b/src/test/kotlin/problems/BlockPlacementQueriesTest.kt
@@ -1,0 +1,43 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class BlockPlacementQueriesTest {
+  @Test
+  fun exampleWithSingleObstacle() {
+    val queries = arrayOf(
+      intArrayOf(1, 2),
+      intArrayOf(2, 3, 3),
+      intArrayOf(2, 3, 1),
+      intArrayOf(2, 2, 2)
+    )
+
+    assertEquals(listOf(false, true, true), getResults(queries))
+  }
+
+  @Test
+  fun updatesSplitExistingSegments() {
+    val queries = arrayOf(
+      intArrayOf(1, 7),
+      intArrayOf(2, 7, 6),
+      intArrayOf(1, 2),
+      intArrayOf(2, 7, 5),
+      intArrayOf(2, 7, 6)
+    )
+
+    assertEquals(listOf(true, true, false), getResults(queries))
+  }
+
+  @Test
+  fun rightBoundaryAtObstacleDoesNotCountTailThroughObstacle() {
+    val queries = arrayOf(
+      intArrayOf(1, 4),
+      intArrayOf(1, 7),
+      intArrayOf(2, 7, 4),
+      intArrayOf(2, 7, 5)
+    )
+
+    assertEquals(listOf(true, false), getResults(queries))
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a solution for the Block Placement Queries problem that efficiently answers placement queries on a line with dynamic obstacles.
- Use a data structure that supports fast obstacle insertion and prefix queries for maximum empty-segment length to meet required time complexity.

### Description

- Add a top-level function `getResults(queries: Array<IntArray>): List<Boolean>` in package `problems` that processes type-1 (insert obstacle) and type-2 (can place block) queries.
- Track obstacle coordinates with a `TreeSet` and maintain a `BlockPlacementSegmentTree` that stores, per obstacle position, the empty segment length ending at that obstacle and supports point updates and prefix-maximum queries.
- Include `BlockPlacementSegmentTree` as a private helper class implementing `updatePoint` and `queryPrefixMaximum` operations used by `getResults`.
- Add unit tests `BlockPlacementQueriesTest` validating single-obstacle behavior, segment splitting after inserts, and right-boundary-at-obstacle edge cases.

### Testing

- Ran the focused unit tests with `./gradlew test --tests problems.BlockPlacementQueriesTest` which completed successfully.
- Ran static analysis with `./gradlew detekt` which completed successfully with no findings reported.
- Ran the full test suite with `./gradlew test` which executed but failed due to 13 existing unrelated test failures in the repository (these failures are not caused by the added files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ad1f69c348321ae029889b0484c38)