### PR TITLE
feat(leetcode): add destroying asteroids solution

### DIFF
--- a/src/main/kotlin/problems/DestroyingAsteroids.kt
+++ b/src/main/kotlin/problems/DestroyingAsteroids.kt
@@ -1,0 +1,16 @@
+package problems
+
+fun asteroidsDestroyed(mass: Int, asteroids: IntArray): Boolean {
+  asteroids.sort()
+  var currentMass = mass.toLong()
+
+  for (asteroidMass in asteroids) {
+    val asteroidMassAsLong = asteroidMass.toLong()
+    if (currentMass < asteroidMassAsLong) {
+      return false
+    }
+    currentMass += asteroidMassAsLong
+  }
+
+  return true
+}

--- a/src/test/kotlin/problems/DestroyingAsteroidsTest.kt
+++ b/src/test/kotlin/problems/DestroyingAsteroidsTest.kt
@@ -1,0 +1,35 @@
+package problems
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class DestroyingAsteroidsTest {
+  @Test
+  fun example1() {
+    val asteroids = intArrayOf(3, 9, 19, 5, 21)
+
+    assertTrue(asteroidsDestroyed(10, asteroids))
+  }
+
+  @Test
+  fun example2() {
+    val asteroids = intArrayOf(4, 9, 23, 4)
+
+    assertFalse(asteroidsDestroyed(5, asteroids))
+  }
+
+  @Test
+  fun handlesUnsortedAsteroidsByAbsorbingSmallestFirst() {
+    val asteroids = intArrayOf(6, 1, 2)
+
+    assertTrue(asteroidsDestroyed(3, asteroids))
+  }
+
+  @Test
+  fun handlesLargeAccumulatedMass() {
+    val asteroids = intArrayOf(Int.MAX_VALUE, Int.MAX_VALUE)
+
+    assertTrue(asteroidsDestroyed(Int.MAX_VALUE, asteroids))
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a solution for LeetCode 2126 that determines whether a planet can absorb all asteroids by always taking the smallest available asteroid first. 

### Description
- Add a top-level function `asteroidsDestroyed(mass: Int, asteroids: IntArray): Boolean` in the `problems` package that sorts `asteroids` and greedily accumulates mass using a `Long` accumulator to avoid overflow. 
- Add unit tests in `src/test/kotlin/problems/DestroyingAsteroidsTest.kt` covering the two examples, an unsorted-input greedy case, and a large-accumulated-mass case. 

### Testing
- Ran `./gradlew test --tests problems.DestroyingAsteroidsTest` and the new test class passed. 
- Ran `./gradlew test` (full suite) and observed unrelated pre-existing failures in other tests (799 tests completed, 14 failed). 
- Ran `./gradlew detekt` and static analysis completed successfully with no reported findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c43b9d3cc83219ca271c84c240793)