### PR TITLE
feat(leetcode): add earliest finish time solution

### DIFF
--- a/src/main/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesI.kt
+++ b/src/main/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesI.kt
@@ -1,0 +1,32 @@
+package problems
+
+fun earliestFinishTime(
+  landStartTime: IntArray,
+  landDuration: IntArray,
+  waterStartTime: IntArray,
+  waterDuration: IntArray
+): Int {
+  var bestLandFinish = Int.MAX_VALUE
+  for (index in landStartTime.indices) {
+    bestLandFinish = minOf(bestLandFinish, landStartTime[index] + landDuration[index])
+  }
+
+  var bestWaterFinish = Int.MAX_VALUE
+  for (index in waterStartTime.indices) {
+    bestWaterFinish = minOf(bestWaterFinish, waterStartTime[index] + waterDuration[index])
+  }
+
+  var answer = Int.MAX_VALUE
+
+  for (index in waterStartTime.indices) {
+    val finishTime = maxOf(bestLandFinish, waterStartTime[index]) + waterDuration[index]
+    answer = minOf(answer, finishTime)
+  }
+
+  for (index in landStartTime.indices) {
+    val finishTime = maxOf(bestWaterFinish, landStartTime[index]) + landDuration[index]
+    answer = minOf(answer, finishTime)
+  }
+
+  return answer
+}

--- a/src/test/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesITest.kt
+++ b/src/test/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesITest.kt
@@ -1,0 +1,36 @@
+package problems
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class EarliestFinishTimeForLandAndWaterRidesITest {
+  @Test
+  fun landFirstCanBeOptimal() {
+    val landStartTime = intArrayOf(2, 8)
+    val landDuration = intArrayOf(4, 1)
+    val waterStartTime = intArrayOf(6)
+    val waterDuration = intArrayOf(3)
+
+    assertEquals(9, earliestFinishTime(landStartTime, landDuration, waterStartTime, waterDuration))
+  }
+
+  @Test
+  fun waterFirstCanBeOptimal() {
+    val landStartTime = intArrayOf(10)
+    val landDuration = intArrayOf(3)
+    val waterStartTime = intArrayOf(1, 5)
+    val waterDuration = intArrayOf(4, 2)
+
+    assertEquals(13, earliestFinishTime(landStartTime, landDuration, waterStartTime, waterDuration))
+  }
+
+  @Test
+  fun waitsForSecondRideOpeningTime() {
+    val landStartTime = intArrayOf(1)
+    val landDuration = intArrayOf(2)
+    val waterStartTime = intArrayOf(10)
+    val waterDuration = intArrayOf(1)
+
+    assertEquals(11, earliestFinishTime(landStartTime, landDuration, waterStartTime, waterDuration))
+  }
+}


### PR DESCRIPTION
### Motivation
- Implement a solution for LeetCode 3633 (Earliest Finish Time for Land and Water Rides I) that computes the earliest possible finish when choosing the order of one land and one water ride. 
- Provide a simple, constant-space linear-time approach and tests that exercise land-first, water-first, and waiting-for-opening scenarios.

### Description
- Add a top-level function `earliestFinishTime` in the `problems` package that computes the minimal finish by summarizing each category with its best finish and evaluating both orders in `O(n + m)` time and `O(1)` extra space (`src/main/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesI.kt`).
- Add unit tests covering land-first optimality, water-first optimality, and waiting for the second ride opening (`src/test/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesITest.kt`).

### Testing
- Ran `./gradlew test`, which executed the suite but reported 13 pre-existing unrelated failing tests in the repository (the new tests ran as part of the suite); the build failed due to those failing tests. 
- Ran `./gradlew detekt`, which completed successfully with no findings reported by the configured rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eea069a5c832196533ddf45fff4bc)