### PR TITLE
feat(leetcode): add earliest finish time rides solution

### DIFF
--- a/src/main/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesII.kt
+++ b/src/main/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesII.kt
@@ -1,0 +1,44 @@
+package problems
+
+fun earliestFinishTime(
+  landStartTime: IntArray,
+  landDuration: IntArray,
+  waterStartTime: IntArray,
+  waterDuration: IntArray
+): Int {
+  var earliestLandFinish = Int.MAX_VALUE
+  for (index in landStartTime.indices) {
+    earliestLandFinish = minOf(
+      earliestLandFinish,
+      landStartTime[index] + landDuration[index]
+    )
+  }
+
+  var landThenWater = Int.MAX_VALUE
+  for (index in waterStartTime.indices) {
+    val finishTime = maxOf(
+      earliestLandFinish,
+      waterStartTime[index]
+    ) + waterDuration[index]
+    landThenWater = minOf(landThenWater, finishTime)
+  }
+
+  var earliestWaterFinish = Int.MAX_VALUE
+  for (index in waterStartTime.indices) {
+    earliestWaterFinish = minOf(
+      earliestWaterFinish,
+      waterStartTime[index] + waterDuration[index]
+    )
+  }
+
+  var waterThenLand = Int.MAX_VALUE
+  for (index in landStartTime.indices) {
+    val finishTime = maxOf(
+      earliestWaterFinish,
+      landStartTime[index]
+    ) + landDuration[index]
+    waterThenLand = minOf(waterThenLand, finishTime)
+  }
+
+  return minOf(landThenWater, waterThenLand)
+}

--- a/src/test/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesIITest.kt
+++ b/src/test/kotlin/problems/EarliestFinishTimeForLandAndWaterRidesIITest.kt
@@ -1,0 +1,45 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EarliestFinishTimeForLandAndWaterRidesIITest {
+  @Test
+  fun landThenWaterCanBeOptimal() {
+    assertEquals(
+      7,
+      earliestFinishTime(
+        landStartTime = intArrayOf(1, 5),
+        landDuration = intArrayOf(3, 2),
+        waterStartTime = intArrayOf(6, 7),
+        waterDuration = intArrayOf(1, 1)
+      )
+    )
+  }
+
+  @Test
+  fun waterThenLandCanBeOptimal() {
+    assertEquals(
+      9,
+      earliestFinishTime(
+        landStartTime = intArrayOf(8, 10),
+        landDuration = intArrayOf(1, 3),
+        waterStartTime = intArrayOf(1, 4),
+        waterDuration = intArrayOf(3, 4)
+      )
+    )
+  }
+
+  @Test
+  fun waitsForSecondRideStartWhenFirstRideFinishesEarly() {
+    assertEquals(
+      12,
+      earliestFinishTime(
+        landStartTime = intArrayOf(1),
+        landDuration = intArrayOf(1),
+        waterStartTime = intArrayOf(10),
+        waterDuration = intArrayOf(2)
+      )
+    )
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a concise top-level Kotlin solution for LeetCode 3635 computing the earliest possible finish when taking one land and one water ride in either order.
- Include unit tests that verify the two ordering strategies and the behavior when waiting for the second ride start.

### Description
- Add top-level function `earliestFinishTime` in `problems` that computes the earliest finish by using the minimal finish time of the first-category ride and evaluating both `land→water` and `water→land` options in `O(n+m)` time and `O(1)` space.
- Implement the algorithm by finding the earliest finish within each category and then computing the best finish for the opposite-category second ride using `maxOf(firstFinish, secondStart) + secondDuration`.
- Add unit tests `EarliestFinishTimeForLandAndWaterRidesIITest` that cover land-first optimal, water-first optimal, and waiting-for-second-ride scenarios.

### Testing
- Ran `./gradlew test`, which failed because the build requires a Java 25 toolchain while the environment initially provided Java 17. 
- Ran `./gradlew detekt`, which failed for the same missing Java 25 toolchain requirement. 
- Installed a temporary JDK 25 and re-ran `./gradlew test`, but dependency resolution failed due to network/SSL issues preventing Gradle from resolving artifacts, so tests could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202db8d350832182a9b83ce3c84a72)