### PR TITLE
feat(leetcode): add total waviness solution

### DIFF
--- a/src/main/kotlin/problems/TotalWaviness.kt
+++ b/src/main/kotlin/problems/TotalWaviness.kt
@@ -1,0 +1,41 @@
+package problems
+
+fun totalWaviness(num1: Int, num2: Int): Int {
+  var totalWaviness = 0
+  var currentNumber = num1
+
+  while (currentNumber <= num2) {
+    totalWaviness += wavinessOfNumber(currentNumber)
+    currentNumber += 1
+  }
+
+  return totalWaviness
+}
+
+private fun wavinessOfNumber(number: Int): Int {
+  val digits = number.toString()
+  if (digits.length < MINIMUM_WAVY_DIGITS) {
+    return 0
+  }
+
+  var waviness = 0
+  var digitIndex = 1
+  while (digitIndex < digits.length - 1) {
+    val leftDigit = digits[digitIndex - 1] - '0'
+    val currentDigit = digits[digitIndex] - '0'
+    val rightDigit = digits[digitIndex + 1] - '0'
+
+    val isPeak = currentDigit > leftDigit && currentDigit > rightDigit
+    val isValley = currentDigit < leftDigit && currentDigit < rightDigit
+
+    if (isPeak || isValley) {
+      waviness += 1
+    }
+
+    digitIndex += 1
+  }
+
+  return waviness
+}
+
+private const val MINIMUM_WAVY_DIGITS = 3

--- a/src/test/kotlin/problems/TotalWavinessTest.kt
+++ b/src/test/kotlin/problems/TotalWavinessTest.kt
@@ -1,0 +1,26 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TotalWavinessTest {
+  @Test
+  fun countsNoWavinessForNumbersWithFewerThanThreeDigits() {
+    assertEquals(0, totalWaviness(1, 99))
+  }
+
+  @Test
+  fun countsSinglePeakAndValleyNumbers() {
+    assertEquals(2, totalWaviness(120, 121))
+  }
+
+  @Test
+  fun sumsWavinessAcrossTheWholeRange() {
+    assertEquals(11, totalWaviness(101, 121))
+  }
+
+  @Test
+  fun countsMultipleMiddleDigitsInOneNumber() {
+    assertEquals(4, totalWaviness(121212, 121212))
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a straightforward solution for LeetCode 3751 that computes the total waviness across a range by checking each number’s middle digits for peaks or valleys.
- Keep problem code as a top-level function and add focused unit tests to verify correctness and edge cases.

### Description
- Add `src/main/kotlin/problems/TotalWaviness.kt` which declares a top-level `totalWaviness(num1: Int, num2: Int): Int` that iterates the range and sums each number’s waviness.
- Implement a private helper `wavinessOfNumber(number: Int): Int` that converts a number to digits, returns `0` for fewer than three digits, and counts strict peaks/valleys among middle digits, and add `MINIMUM_WAVY_DIGITS` constant.
- Add `src/test/kotlin/problems/TotalWavinessTest.kt` with tests for numbers with <3 digits, single peak/valley cases, range summing, and multiple middle-digit waviness in one number.

### Testing
- Ran `./gradlew test --tests problems.TotalWavinessTest` and the `TotalWaviness` test suite passed.
- Ran `./gradlew detekt` and static analysis passed with no detekt violations.
- Ran full test suite with `./gradlew test` where unrelated existing tests in the repository failed; the newly added tests still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2184f450588321b8dce80b1635db19)