### PR TITLE
feat(leetcode): add total waviness solution (digit DP)

### DIFF
--- a/src/main/kotlin/problems/TotalWavinessOfNumbersInRangeII.kt
+++ b/src/main/kotlin/problems/TotalWavinessOfNumbersInRangeII.kt
@@ -1,0 +1,98 @@
+package problems
+
+private const val NO_DIGIT = 10
+private const val UNVISITED = -1L
+
+fun totalWaviness(num1: Long, num2: Long): Long = totalWavinessUpTo(num2) - totalWavinessUpTo(num1 - 1)
+
+private fun totalWavinessUpTo(bound: Long): Long {
+  if (bound < 0L) return 0L
+
+  val digits = bound.toString().map { digit -> digit - '0' }
+  val memoWays = Array(digits.size + 1) {
+    Array(2) {
+      Array(11) { LongArray(11) { UNVISITED } }
+    }
+  }
+  val memoWaviness = Array(digits.size + 1) {
+    Array(2) {
+      Array(11) { LongArray(11) { UNVISITED } }
+    }
+  }
+
+  fun dfs(
+    position: Int,
+    isTight: Boolean,
+    hasStarted: Boolean,
+    lastOne: Int,
+    lastTwo: Int,
+  ): Pair<Long, Long> {
+    if (position == digits.size) return 1L to 0L
+
+    val startedIndex = if (hasStarted) 1 else 0
+    if (!isTight && memoWays[position][startedIndex][lastOne][lastTwo] != UNVISITED) {
+      return memoWays[position][startedIndex][lastOne][lastTwo] to
+        memoWaviness[position][startedIndex][lastOne][lastTwo]
+    }
+
+    val limit = if (isTight) digits[position] else 9
+    var totalWays = 0L
+    var totalWaviness = 0L
+
+    for (digit in 0..limit) {
+      val nextTight = isTight && digit == limit
+      var nextHasStarted = hasStarted
+      var nextLastOne = lastOne
+      var nextLastTwo = lastTwo
+      var extra = 0L
+
+      if (!hasStarted) {
+        if (digit == 0) {
+          nextHasStarted = false
+          nextLastOne = NO_DIGIT
+          nextLastTwo = NO_DIGIT
+        } else {
+          nextHasStarted = true
+          nextLastOne = digit
+          nextLastTwo = NO_DIGIT
+        }
+      } else {
+        nextHasStarted = true
+        nextLastTwo = lastOne
+        nextLastOne = digit
+
+        if (lastTwo != NO_DIGIT && isPeakOrValley(lastTwo, lastOne, digit)) {
+          extra = 1L
+        }
+      }
+
+      val (childWays, childWaviness) = dfs(
+        position = position + 1,
+        isTight = nextTight,
+        hasStarted = nextHasStarted,
+        lastOne = nextLastOne,
+        lastTwo = nextLastTwo,
+      )
+      totalWays += childWays
+      totalWaviness += childWaviness + extra * childWays
+    }
+
+    if (!isTight) {
+      memoWays[position][startedIndex][lastOne][lastTwo] = totalWays
+      memoWaviness[position][startedIndex][lastOne][lastTwo] = totalWaviness
+    }
+
+    return totalWays to totalWaviness
+  }
+
+  return dfs(
+    position = 0,
+    isTight = true,
+    hasStarted = false,
+    lastOne = NO_DIGIT,
+    lastTwo = NO_DIGIT,
+  ).second
+}
+
+private fun isPeakOrValley(left: Int, middle: Int, right: Int): Boolean =
+  (middle > left && middle > right) || (middle < left && middle < right)

--- a/src/test/kotlin/problems/TotalWavinessOfNumbersInRangeIITest.kt
+++ b/src/test/kotlin/problems/TotalWavinessOfNumbersInRangeIITest.kt
@@ -1,0 +1,24 @@
+package problems
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TotalWavinessOfNumbersInRangeIITest {
+  @Test
+  fun returnsZeroWhenNumbersAreTooShort() {
+    assertEquals(0L, totalWaviness(0L, 99L))
+  }
+
+  @Test
+  fun countsSingleThreeDigitPeaksAndValleys() {
+    assertEquals(1L, totalWaviness(120L, 120L))
+    assertEquals(1L, totalWaviness(101L, 101L))
+    assertEquals(0L, totalWaviness(111L, 111L))
+  }
+
+  @Test
+  fun countsAllCompletionsInARange() {
+    assertEquals(10L, totalWaviness(100L, 120L))
+    assertEquals(525L, totalWaviness(0L, 999L))
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a solution for LeetCode-style problem to compute the total waviness of numbers in a range using digit DP over prefixes.

### Description

- Add a top-level function `totalWaviness(num1: Long, num2: Long)` implemented in `src/main/kotlin/problems/TotalWavinessOfNumbersInRangeII.kt` that uses memoized digit DP to return the total waviness across a range.
- Track DP state with position, `isTight`, `hasStarted`, and the last two digits, and memoize both `ways` and `waviness` per state to accumulate contributions efficiently.
- Include helper `isPeakOrValley` to detect local peaks/valleys for completed digit triples.
- Add unit tests in `src/test/kotlin/problems/TotalWavinessOfNumbersInRangeIITest.kt` covering too-short numbers, single three-digit peak/valley cases, and aggregated ranges.

### Testing

- Ran `./gradlew test --tests problems.TotalWavinessOfNumbersInRangeIITest` and the targeted test passed successfully.
- Ran `./gradlew test` and the full repository test suite failed due to 13 unrelated existing test failures (repository-wide issues), not caused by the added files.
- Ran `./gradlew detekt` and static analysis completed with no Detekt violations reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22e98cbcf48321bbb38b71ebafc0cf)